### PR TITLE
chore(github): separate ansible hook

### DIFF
--- a/.github/workflows/pre-commit-ansible-autoupdate.yaml
+++ b/.github/workflows/pre-commit-ansible-autoupdate.yaml
@@ -1,0 +1,45 @@
+# This file is automatically synced from:
+# https://github.com/autowarefoundation/sync-file-templates
+# To make changes, update the source repository and follow the guidelines in its README.
+
+name: pre-commit-optional-autoupdate
+
+on:
+  schedule:
+    - cron: 0 0 1 1,4,7,10 * # quarterly
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-secret:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/check-secret.yaml@v1
+    secrets:
+      secret: ${{ secrets.APP_ID }}
+
+  pre-commit-optional-autoupdate:
+    needs: check-secret
+    if: ${{ needs.check-secret.outputs.set == 'true' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Run pre-commit-autoupdate
+        uses: autowarefoundation/autoware-github-actions/pre-commit-autoupdate@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          pre-commit-config: .pre-commit-config-optional.yaml
+          pr-labels: |
+            tag:bot
+            tag:pre-commit-autoupdate
+          pr-branch: pre-commit-optional-autoupdate
+          pr-title: "ci(pre-commit-optional): autoupdate"
+          pr-commit-message: "ci(pre-commit-optional): autoupdate"
+          auto-merge-method: squash

--- a/.github/workflows/pre-commit-ansible.yaml
+++ b/.github/workflows/pre-commit-ansible.yaml
@@ -1,0 +1,37 @@
+name: pre-commit-ansible-autoupdate
+
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+
+jobs:
+  check-secret:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/check-secret.yaml@v1
+    secrets:
+      secret: ${{ secrets.APP_ID }}
+
+  pre-commit-ansible-autoupdate:
+    needs: check-secret
+    if: ${{ needs.check-secret.outputs.set == 'true' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Run pre-commit-autoupdate
+        uses: autowarefoundation/autoware-github-actions/pre-commit-autoupdate@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          pre-commit-config: .pre-commit-config-ansible.yaml
+          pr-labels: |
+            tag:bot
+            tag:pre-commit-autoupdate
+          pr-branch: pre-commit-ansible-autoupdate
+          pr-title: "ci(pre-commit-ansible): autoupdate"
+          pr-commit-message: "ci(pre-commit-ansible): autoupdate"
+          auto-merge-method: squash

--- a/.pre-commit-config-ansible.yaml
+++ b/.pre-commit-config-ansible.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/ansible/ansible-lint.git
+    rev: v25.9.0
+    hooks:
+      - id: ansible-lint
+        additional_dependencies:
+          - ansible

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,10 +89,3 @@ repos:
     hooks:
       - id: hadolint
         exclude: .svg$
-
-  - repo: https://github.com/ansible/ansible-lint.git
-    rev: v25.9.0
-    hooks:
-      - id: ansible-lint
-        additional_dependencies:
-          - ansible

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -75,6 +75,10 @@
           "value": "${workspaceFolder}/.pre-commit-config.yaml"
         },
         {
+          "label": "pre-commit-config-ansible.yaml",
+          "value": "${workspaceFolder}/.pre-commit-config-ansible.yaml"
+        },
+        {
           "label": "pre-commit-config-optional.yaml",
           "value": "${workspaceFolder}/.pre-commit-config-optional.yaml"
         }


### PR DESCRIPTION
## Summary

Ansible hook for pre-commit is to heavy:
```
build of https://github.com/ansible/ansible-lint.git:ansible@v25.9.0 for python@python3.12 exceeds tier max size 250MiB: 420.6MiB
```

This PR removes Ansible hook from default hooks list.

## Related Issues

<!-- Link related issues or feature requests -->

## Checklist

- [ ] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/main/contributing/contribution-overview/).
- [ ] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/main/contributing/pull-request-guidelines/).

## Additional Notes

<!-- Anything else reviewers should know? -->

## Additional Log and Media

<!-- Any additional logs or information. -->
