### PR TITLE
chore: uid/gid handling, data path

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,9 +4,21 @@ FROM $BASE_IMAGE
 
 # Set shell to bash with pipefail for safer pipe handling
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-USER root
 
-# Update ROS key and repository configuration, then install packages via apt-get
+# Create autoware-ml user
+ARG USERNAME=autoware-ml
+ARG USER_UID=1000
+ARG USER_GID=${USER_UID}
+RUN groupadd --gid ${USER_GID} ${USERNAME} \
+    && useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME} -s /bin/bash \
+    && echo "${USERNAME} ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME} \
+    && chmod 0440 /etc/sudoers.d/${USERNAME} \
+    && mkdir -p /tmp/xdg \
+    && chown ${USER_UID}:${USER_GID} /tmp/xdg \
+    && chmod 700 /tmp/xdg \
+    && gosu ${USERNAME} env HOME=/home/${USERNAME} _TYPER_COMPLETE_TEST_DISABLE_SHELL_DETECTION=1 ${USERNAME} --install-completion bash
+
+# Install development tools via apt-get
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   bash-completion \
   bear \
@@ -39,10 +51,3 @@ RUN CLANGD_VERSION=$(curl -fsSL "https://api.github.com/repos/clangd/clangd/rele
   && ln -s "/opt/clangd_${CLANGD_VERSION}/bin/clangd" /usr/local/bin/clangd \
   && rm -rf /tmp/clangd-linux.zip \
   && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* "$HOME"/.cache
-
-# Switch back user
-USER autoware-ml
-
-# Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD echo "Container is healthy"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,36 +9,35 @@
     "options": ["--network=host"]
   },
   "remoteUser": "autoware-ml",
+  "containerUser": "autoware-ml",
+  "updateRemoteUserUID": true,
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
   "workspaceFolder": "/workspace",
   "hostRequirements": {
     "gpu": true
   },
+  "privileged": true,
+  "containerEnv": {
+    "XDG_RUNTIME_DIR": "/tmp/xdg",
+    "DISPLAY": "${localEnv:DISPLAY}",
+    "XAUTHORITY": "${localEnv:XAUTHORITY}",
+    "NVIDIA_DRIVER_CAPABILITIES": "all"
+  },
+  "mounts": [
+    "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind",
+    "source=/etc/localtime,target=/etc/localtime,type=bind,readonly",
+    "source=/dev/dri,target=/dev/dri,type=bind,readonly",
+    "source=${localEnv:AUTOWARE_ML_DATA_PATH},target=/autoware-ml-data,type=bind",
+    "source=${localEnv:HOME}/.ssh,target=/home/autoware-ml/.ssh,type=bind"
+  ],
   "runArgs": [
-    "-it",
-    "--rm",
-    "--name=autoware-ml-${localEnv:USER}",
-    "--privileged",
-    "--env",
-    "DISPLAY=${env:DISPLAY}",
-    "--env",
-    "XAUTHORITY=${env:XAUTHORITY}",
-    "--env",
-    "NVIDIA_DRIVER_CAPABILITIES=all",
+    "--name=autoware-ml-${localEnv:USER}-dev",
     "--net=host",
     "--pid=host",
     "--ipc=host",
-    "--ulimit",
-    "memlock=-1",
-    "--ulimit",
-    "stack=67108864",
-    "--volume=/tmp/.X11-unix/:/tmp/.X11-unix",
-    "--volume=/etc/localtime:/etc/localtime:ro",
-    "--volume=/dev/dri:/dev/dri:ro",
-    "--volume=${localEnv:AUTOWARE_ML_DATA_PATH}:/workspace/data",
-    "--volume=${env:HOME}/.ssh:/home/autoware-ml/.ssh",
-    "--gpus",
-    "all"
+    "--ulimit=memlock=-1",
+    "--ulimit=stack=67108864",
+    "--gpus=all"
   ],
   "customizations": {
     "vscode": {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,22 +1,16 @@
 FROM pytorch/pytorch:2.9.1-cuda12.8-cudnn9-devel
 
-ARG USERNAME=autoware-ml
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Core environment variables
-ENV AUTOWARE_ML_DATA_PATH="/workspace/data" \
+ENV AUTOWARE_ML_DATA_PATH="/autoware-ml-data" \
   CUDA_HOME="/usr/local/cuda" \
   FORCE_CUDA="1" \
   LC_ALL=C.UTF-8 \
-  PATH=$PATH:/home/$USERNAME/.local/bin \
   PYTHONPATH=/workspace \
   SHELL=/bin/bash \
   TORCH_CUDA_ARCH_LIST="8.0 8.6 8.9 9.0 12.0+PTX" \
-  TORCH_NVCC_FLAGS="-Xfatbin -compress-all" \
-  XDG_RUNTIME_DIR=/tmp/xdg/$USER_UID
+  TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 
 # Prompt customization
 ENV GIT_PS1_DESCRIBE_STYLE=contains \
@@ -34,22 +28,18 @@ RUN apt-get update && \
   bash-completion \
   build-essential \
   git \
+  gosu \
   ninja-build \
   sudo \
   vim \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && gosu nobody true
 
-# Add user
-RUN groupadd --gid "$USER_GID" "$USERNAME" \
-  && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" \
-  && echo "$USERNAME" ALL=\(root\) NOPASSWD:ALL > "/etc/sudoers.d/$USERNAME" \
-  && chmod 0440 "/etc/sudoers.d/$USERNAME" \
-  && mkdir -p /workspace /ccache "$XDG_RUNTIME_DIR" \
-  && chown -R "$USERNAME":"$USERNAME" /workspace /ccache "$XDG_RUNTIME_DIR" \
-  && chmod 700 "$XDG_RUNTIME_DIR"
+# Create workspace and cache directories (ownership will be set by entrypoint)
+RUN mkdir -p /workspace /ccache
 
 # Set workspace
-COPY --chown=$USERNAME:$USERNAME . /workspace/
+COPY . /workspace/
 WORKDIR /workspace
 
 # Install pyproject dependencies
@@ -57,11 +47,8 @@ WORKDIR /workspace
 RUN pip install --no-cache-dir hatchling read_version uv wheel_stub \
   && uv pip install --system --no-cache .[dev] --no-build-isolation
 
-# Set user
-USER $USERNAME
-
-# Install bash completion for user
-RUN autoware-ml --install-completion bash || true
+# Copy and set up entrypoint
+COPY docker/entrypoint.sh /entrypoint.sh
 
 # Metadata
 LABEL maintainer="TIER IV, Inc." \
@@ -70,4 +57,5 @@ LABEL maintainer="TIER IV, Inc." \
   org.opencontainers.image.source="https://github.com/tier4/autoware-ml" \
   org.opencontainers.image.vendor="TIER IV, Inc."
 
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/bin/bash"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -18,7 +18,7 @@ fi
 
 if ! getent passwd "${HOST_UID}" >/dev/null 2>&1; then
     useradd -u "${HOST_UID}" -g "${HOST_GID}" -m -s /bin/bash "autoware-ml"
-    echo "autoware-ml ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/autoware-ml
+    echo "autoware-ml ALL=(root) NOPASSWD:ALL" >/etc/sudoers.d/autoware-ml
     chmod 0440 /etc/sudoers.d/autoware-ml
     gosu "${HOST_UID}" autoware-ml --install-completion bash
     echo "User 'autoware-ml' was created with UID: ${HOST_UID} and GID: ${HOST_GID}."

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Entrypoint script to create user matching host UID/GID and switch to it using gosu
+set -e
+
+HOST_UID=${HOST_UID:-1000}
+HOST_GID=${HOST_GID:-1000}
+
+# If not running as root, just exec the command
+if [ "$(id -u)" != "0" ]; then
+    cd /workspace
+    exec "$@"
+fi
+
+# Create group and user if they don't exist
+if ! getent group "${HOST_GID}" >/dev/null 2>&1; then
+    groupadd -g "${HOST_GID}" "autoware-ml"
+fi
+
+if ! getent passwd "${HOST_UID}" >/dev/null 2>&1; then
+    useradd -u "${HOST_UID}" -g "${HOST_GID}" -m -s /bin/bash "autoware-ml"
+    echo "autoware-ml ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/autoware-ml
+    chmod 0440 /etc/sudoers.d/autoware-ml
+    gosu "${HOST_UID}" autoware-ml --install-completion bash
+    echo "User 'autoware-ml' was created with UID: ${HOST_UID} and GID: ${HOST_GID}."
+fi
+
+# Get actual username and home directory for the UID
+USERNAME=$(getent passwd "${HOST_UID}" | cut -d: -f1)
+USER_HOME=$(getent passwd "${HOST_UID}" | cut -d: -f6)
+
+# Create XDG runtime directory (passed via XDG_RUNTIME_DIR env var)
+mkdir -p /tmp/xdg
+chown "${HOST_UID}:${HOST_GID}" /tmp/xdg
+chmod 700 /tmp/xdg
+
+# Export necessary environment variables for gosu
+export HOME="${USER_HOME}"
+export USER="${USERNAME}"
+
+# Switch to user and exec command
+cd /workspace
+exec gosu "${USERNAME}" "$@"

--- a/docs/contributing/adding-models.md
+++ b/docs/contributing/adding-models.md
@@ -257,7 +257,7 @@ defaults:
   - /my_task/my_model_base
   - _self_
 
-data_root: /workspace/data/my_dataset
+data_root: /autoware-ml-data/my_dataset
 
 datamodule:
   data_root: ${data_root}

--- a/docs/models/calibration-status.md
+++ b/docs/models/calibration-status.md
@@ -80,8 +80,8 @@ train_transforms:
 autoware-ml create-dataset \
     --dataset nuscenes \
     --task calibration_status \
-    --root-path /workspace/data/nuscenes \
-    --out-dir /workspace/data/nuscenes/info
+    --root-path /autoware-ml-data/nuscenes \
+    --out-dir /autoware-ml-data/nuscenes/info
 
 # Train
 autoware-ml train --config-name tasks/calibration_status/resnet18_nuscenes
@@ -94,7 +94,7 @@ defaults:
   - /tasks/calibration_status/resnet18_base
   - _self_
 
-data_root: /workspace/data/nuscenes
+data_root: /autoware-ml-data/nuscenes
 
 datamodule:
   _target_: autoware_ml.datamodule.nuscenes.calibration_status.NuscenesCalibrationDataModule

--- a/set_data_path.sh
+++ b/set_data_path.sh
@@ -19,6 +19,7 @@ set -e
 VAR_NAME="AUTOWARE_ML_DATA_PATH"
 NEW_PATH="$1"
 BASHRC_FILE="$HOME/.bashrc"
+PROFILE_FILE="$HOME/.profile"
 
 show_help() {
     cat <<EOF
@@ -35,7 +36,7 @@ Examples:
   Incorrect: $0 /data/datasets/nuscenes
 
 The script will:
-  - Add or update ${VAR_NAME} in ${BASHRC_FILE}
+  - Add or update ${VAR_NAME} in ${BASHRC_FILE} and ${PROFILE_FILE}
   - Skip execution if running inside a Docker container
 
 EOF
@@ -62,10 +63,12 @@ fi
 NEW_PATH="${NEW_PATH%/}"
 
 sed -i "/^export ${VAR_NAME}=.*/d" "$BASHRC_FILE"
+sed -i "/^export ${VAR_NAME}=.*/d" "$PROFILE_FILE"
 
 echo "export ${VAR_NAME}=\"$NEW_PATH\"" >>"$BASHRC_FILE"
+echo "export ${VAR_NAME}=\"$NEW_PATH\"" >>"$PROFILE_FILE"
 
-echo "Successfully set ${VAR_NAME}=\"$NEW_PATH\" in ${BASHRC_FILE}"
+echo "Successfully set ${VAR_NAME}=\"$NEW_PATH\" in ${BASHRC_FILE} and ${PROFILE_FILE}"
 echo ""
 echo "Note: This path should be the root directory for datasets (e.g., /data/datasets),"
 echo "      not a path to a specific dataset. Dataset-specific directories are"


### PR DESCRIPTION
## Summary

Unify container user handling and data path conventions. Devcontainer and Docker images now rely on an entrypoint to create a host‑UID user at runtime, shift dataset mounts from /workspace/data to /autoware-ml-data, and align container environment/mounts accordingly. run.sh gains stop options and passes host UID/GID for correct permissions. Dataset docs and the data path helper script are updated to match the new mount.

## Related Issues

<!-- Link related issues or feature requests -->

## Checklist

- [ ] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [ ] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

## Additional Notes

## Additional Log and Media

<!-- Any additional logs or information. -->
