### PR TITLE
chore: refine mounting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,7 @@
     "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind",
     "source=/etc/localtime,target=/etc/localtime,type=bind,readonly",
     "source=/dev/dri,target=/dev/dri,type=bind,readonly",
-    "source=${localEnv:AUTOWARE_ML_DATA_PATH},target=/autoware-ml-data,type=bind",
+    "source=${localEnv:AUTOWARE_ML_DATA_PATH},target=/workspace/data,type=bind,bind-propagation=rshared",
     "source=${localEnv:HOME}/.ssh,target=/home/autoware-ml/.ssh,type=bind"
   ],
   "runArgs": [

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM pytorch/pytorch:2.9.1-cuda12.8-cudnn9-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Core environment variables
-ENV AUTOWARE_ML_DATA_PATH="/autoware-ml-data" \
+ENV AUTOWARE_ML_DATA_PATH="/workspace/data" \
   CUDA_HOME="/usr/local/cuda" \
   FORCE_CUDA="1" \
   LC_ALL=C.UTF-8 \

--- a/docs/contributing/adding-models.md
+++ b/docs/contributing/adding-models.md
@@ -257,7 +257,7 @@ defaults:
   - /my_task/my_model_base
   - _self_
 
-data_root: /autoware-ml-data/my_dataset
+data_root: /workspace/data/my_dataset
 
 datamodule:
   data_root: ${data_root}

--- a/docs/models/calibration-status.md
+++ b/docs/models/calibration-status.md
@@ -80,8 +80,8 @@ train_transforms:
 autoware-ml create-dataset \
     --dataset nuscenes \
     --task calibration_status \
-    --root-path /autoware-ml-data/nuscenes \
-    --out-dir /autoware-ml-data/nuscenes/info
+    --root-path /workspace/data/nuscenes \
+    --out-dir /workspace/data/nuscenes/info
 
 # Train
 autoware-ml train --config-name tasks/calibration_status/resnet18_nuscenes
@@ -94,7 +94,7 @@ defaults:
   - /tasks/calibration_status/resnet18_base
   - _self_
 
-data_root: /autoware-ml-data/nuscenes
+data_root: /workspace/data/nuscenes
 
 datamodule:
   _target_: autoware_ml.datamodule.nuscenes.calibration_status.NuscenesCalibrationDataModule


### PR DESCRIPTION
## Summary

Replaced `-v` with `--mount ... bind-propagation=rshared`.

Fixes "Too many levels of symbolic links": The server-based storage may has nested mounts. `rshared` tells Docker to follow those recursive mount points into the container properly.

This PR also restores `/workspace/data` as a framework data path: previous change to `/autoware-ml-data` was unnecessary. Docker handles nested mounts (`/workspace` + `/workspace/data`) just fine as long as the propagation is set correctly.

Aligned mounting points for Dev Container and shell script.

## Related Issues

<!-- Link related issues or feature requests -->

## Checklist

- [ ] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [ ] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

## Additional Notes

<!-- Anything else reviewers should know? -->

## Additional Log and Media

<!-- Any additional logs or information. -->
