### PR TITLE
fix(ops): use setuptools Extension types in build helper

### DIFF
--- a/autoware_ml/ops/build.py
+++ b/autoware_ml/ops/build.py
@@ -23,6 +23,7 @@ import os
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
+from setuptools import Extension
 import torch
 from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDAExtension
 
@@ -36,7 +37,7 @@ def make_cuda_ext(
     sources_cuda: Sequence[str] | None = None,
     extra_args: Sequence[str] | None = None,
     extra_include_path: Sequence[str] | None = None,
-):
+) -> Extension:
     """Create a C++ or CUDA extension for a module.
 
     Args:
@@ -85,7 +86,7 @@ def make_cuda_ext(
     )
 
 
-def get_ext_modules() -> list[CppExtension | CUDAExtension]:
+def get_ext_modules() -> list[Extension]:
     """Return extension modules shipped with Autoware-ML ops.
 
     Returns:


### PR DESCRIPTION
## Summary

Fix the ops build helper annotations to use `setuptools.Extension`.

## Related Issues

<!-- Link related issues or feature requests -->

## Checklist

- [ ] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [ ] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

## Additional Notes

<!-- Anything else reviewers should know? -->

## Additional Log and Media

<!-- Any additional logs or information. -->
