### PR TITLE
chore(docker): stop publishing commit-sha image tags

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -131,9 +131,7 @@ jobs:
       - name: Tag Docker image
         run: |
           docker tag "${IMAGE_TAG}" ghcr.io/tier4/autoware-ml:latest
-          docker tag "${IMAGE_TAG}" ghcr.io/tier4/autoware-ml:${GITHUB_SHA}
 
       - name: Push Docker image
         run: |
           docker push ghcr.io/tier4/autoware-ml:latest
-          docker push ghcr.io/tier4/autoware-ml:${GITHUB_SHA}


### PR DESCRIPTION
## Summary

Remove commit-sha from deployed images tags.

## Related Issues

<!-- Link related issues or feature requests -->

## Checklist

- [ ] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [ ] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

## Additional Notes

<!-- Anything else reviewers should know? -->

## Additional Log and Media

<!-- Any additional logs or information. -->
