### PR TITLE
feat(ptv3): configurable embedding stem (kernel size + linear stem)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -214,6 +214,7 @@
     "unpad",
     "unpool",
     "unpooling",
+    "Utonia",
     "varlen",
     "Xfatbin",
     "xytext",

--- a/autoware_ml/models/segmentation3d/backbones/ptv3.py
+++ b/autoware_ml/models/segmentation3d/backbones/ptv3.py
@@ -739,17 +739,20 @@ class Embedding(PointModule):
     before the hierarchical PTv3 stages are applied.
     """
 
-    def __init__(self, in_channels: int, embed_channels: int) -> None:
+    def __init__(self, in_channels: int, embed_channels: int, kernel_size: int = 5) -> None:
         """Initialize the sparse-convolution embedding stem.
 
         Args:
             in_channels: Input feature dimension.
             embed_channels: Output embedding dimension.
+            kernel_size: Submanifold-conv stem kernel size. The default of 5
+                preserves the original 5x5x5 stem; 3 rides spconv's implicit-GEMM
+                path like the network's other convs.
         """
         super().__init__()
         self.stem = PointSequential(
             spconv.SubMConv3d(
-                in_channels, embed_channels, kernel_size=5, padding=1, bias=False, indice_key="stem"
+                in_channels, embed_channels, kernel_size=kernel_size, bias=False, indice_key="stem"
             ),
             nn.BatchNorm1d(embed_channels, eps=1e-3, momentum=0.01),
             nn.GELU(),
@@ -800,6 +803,7 @@ class PointTransformerV3Backbone(PointModule):
         enable_flash: bool,
         upcast_attention: bool,
         upcast_softmax: bool,
+        stem_kernel_size: int = 5,
     ) -> None:
         """Initialize the PTv3 encoder-decoder backbone.
 
@@ -827,13 +831,15 @@ class PointTransformerV3Backbone(PointModule):
             enable_flash: Whether to use flash attention.
             upcast_attention: Whether to upcast Q/K before attention.
             upcast_softmax: Whether to upcast logits before softmax.
+            stem_kernel_size: Embedding-stem submanifold-conv kernel size. The
+                default of 5 preserves the original 5x5x5 stem.
         """
         super().__init__()
 
         self.order = list(order)
         self.shuffle_orders = shuffle_orders
         stage_count = len(enc_depths)
-        self.embedding = Embedding(in_channels, enc_channels[0])
+        self.embedding = Embedding(in_channels, enc_channels[0], kernel_size=stem_kernel_size)
 
         enc_drop_path = [value.item() for value in torch.linspace(0, drop_path, sum(enc_depths))]
         self.enc = PointSequential()

--- a/autoware_ml/models/segmentation3d/backbones/ptv3.py
+++ b/autoware_ml/models/segmentation3d/backbones/ptv3.py
@@ -739,21 +739,36 @@ class Embedding(PointModule):
     before the hierarchical PTv3 stages are applied.
     """
 
-    def __init__(self, in_channels: int, embed_channels: int, kernel_size: int = 5) -> None:
-        """Initialize the sparse-convolution embedding stem.
+    def __init__(
+        self,
+        in_channels: int,
+        embed_channels: int,
+        kernel_size: int = 5,
+        stem_type: str = "conv",
+    ) -> None:
+        """Initialize the embedding stem.
 
         Args:
             in_channels: Input feature dimension.
             embed_channels: Output embedding dimension.
-            kernel_size: Submanifold-conv stem kernel size. The default of 5
-                preserves the original 5x5x5 stem; 3 rides spconv's implicit-GEMM
-                path like the network's other convs.
+            kernel_size: Submanifold-conv stem kernel size (ignored for the
+                linear stem). The default of 5 preserves the original 5x5x5 stem;
+                3 rides spconv's implicit-GEMM path like the network's other convs.
+            stem_type: Stem variant. ``"conv"`` (default) uses a submanifold conv;
+                ``"linear"`` uses a Utonia-style (PT-v3m3) per-point ``nn.Linear``.
         """
         super().__init__()
-        self.stem = PointSequential(
-            spconv.SubMConv3d(
+        if stem_type == "linear":
+            # Utonia-style stem: drop the submanifold conv for a per-point Linear.
+            stem = nn.Linear(in_channels, embed_channels)
+        elif stem_type == "conv":
+            stem = spconv.SubMConv3d(
                 in_channels, embed_channels, kernel_size=kernel_size, bias=False, indice_key="stem"
-            ),
+            )
+        else:
+            raise ValueError(f"Unknown stem_type: {stem_type!r} (expected 'conv' or 'linear')")
+        self.stem = PointSequential(
+            stem,
             nn.BatchNorm1d(embed_channels, eps=1e-3, momentum=0.01),
             nn.GELU(),
         )
@@ -804,6 +819,7 @@ class PointTransformerV3Backbone(PointModule):
         upcast_attention: bool,
         upcast_softmax: bool,
         stem_kernel_size: int = 5,
+        stem_type: str = "conv",
     ) -> None:
         """Initialize the PTv3 encoder-decoder backbone.
 
@@ -833,13 +849,17 @@ class PointTransformerV3Backbone(PointModule):
             upcast_softmax: Whether to upcast logits before softmax.
             stem_kernel_size: Embedding-stem submanifold-conv kernel size. The
                 default of 5 preserves the original 5x5x5 stem.
+            stem_type: Embedding-stem variant, ``"conv"`` (default) or
+                ``"linear"``. See :class:`Embedding`.
         """
         super().__init__()
 
         self.order = list(order)
         self.shuffle_orders = shuffle_orders
         stage_count = len(enc_depths)
-        self.embedding = Embedding(in_channels, enc_channels[0], kernel_size=stem_kernel_size)
+        self.embedding = Embedding(
+            in_channels, enc_channels[0], kernel_size=stem_kernel_size, stem_type=stem_type
+        )
 
         enc_drop_path = [value.item() for value in torch.linspace(0, drop_path, sum(enc_depths))]
         self.enc = PointSequential()


### PR DESCRIPTION
## Motivation

The PTv3 embedding stem is hard-coded to a 5×5×5 submanifold conv. On spconv, this large kernel falls onto the slow native (non-implicit-GEMM) path — unlike the network's 3×3×3 convs, which ride spconv's default implicit-GEMM path — so the stem is a disproportionate latency cost at export/inference time.

This PR adds **options** to avoid that low-performance 5×5×5 stem, **while keeping the existing behavior as the default** so existing configs and checkpoints are unaffected.

Two knobs are threaded through `PointTransformerV3Backbone` → `Embedding`:

- **`stem_kernel_size`** (default `5`): shrink the stem conv, e.g. to `3`, so it rides spconv's implicit-GEMM path like the rest of the network.
- **`stem_type`** (default `"conv"`): set `"linear"` for a Utonia-style (PT-v3m3) per-point `nn.Linear` stem that drops the submanifold conv entirely.

Both default to the original 5×5×5 conv, so this change is **fully backward compatible** — no behavior change unless a config opts in. The linear stem stays export-friendly (plain `nn.Linear`); the conv stem continues to go through the existing exportable-conv replacement.

## Results

> Measured on the **AWML** pipeline; ported here unchanged. Not yet re-trained/benchmarked on this pipeline.

| Variant | Config change | GPU total (ms) | GPU infer | GPU preproc | faster vs t18 | mIoU | best epoch |
|---|---|---|---|---|---|---|---|
| ptv3-t18 | _default_ (`stem_type="conv"`, `stem_kernel_size=5`) | 30.44 ± 0.95 | 29.09 | 1.33 | — | 0.4892 | 50 |
| stem-3x3x3 | `stem_kernel_size=3` | 27.40 ± 0.36 | 26.05 | 1.34 | +11.1% | 0.4874 | 40 |
| stem-linear | `stem_type="linear"` | 27.13 ± 0.75 | 25.74 | 1.38 | +12.2% | 0.4966 | 27 |

Both alternative stems are ~11–12% faster end-to-end than the 5×5×5 baseline, with the linear stem also slightly improving mIoU.

## Visual Comparison

> Exported from the **AWML** pipeline

https://github.com/user-attachments/assets/d4a1e1c4-b6b7-4a68-ab22-d0bd6e8237fa

## Changes

- `feat(ptv3): make embedding stem kernel size configurable` — adds `stem_kernel_size` (default 5), drops the inert `padding` arg from the submanifold stem conv.
- `feat(ptv3): add linear (Utonia-style) embedding stem option` — adds `stem_type` (default `"conv"`); `"linear"` swaps the spconv stem for `nn.Linear`.

Ported from tier4/AWML#216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
