### PR TITLE
refactor(deploy): allow export specs to provide dynamic axes

### DIFF
--- a/autoware_ml/scripts/deploy.py
+++ b/autoware_ml/scripts/deploy.py
@@ -222,6 +222,7 @@ def main(cfg: DictConfig) -> None:
                         module_onnx_cfg,
                         export_spec.input_param_names,
                         export_spec.output_names,
+                        export_spec.dynamic_axes,
                         module_onnx_path,
                     )
                     onnx_exported_paths.append(module_onnx_path)

--- a/autoware_ml/tests/utils/test_deploy.py
+++ b/autoware_ml/tests/utils/test_deploy.py
@@ -72,10 +72,44 @@ def test_export_to_onnx_prefers_export_spec_output_names(tmp_path: Path) -> None
         onnx_cfg=onnx_cfg,
         input_param_names=["input"],
         output_names_override=["exported_output"],
+        dynamic_axes_override=None,
         output_path=output_path,
     )
 
     assert output_path.exists()
+
+
+def test_export_to_onnx_prefers_export_spec_dynamic_axes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured_kwargs: dict[str, object] = {}
+    monkeypatch.setattr(
+        torch.onnx,
+        "export",
+        lambda **kwargs: captured_kwargs.update(kwargs),
+    )
+
+    dynamic_axes_override = {"input": {0: "export_spec_batch"}}
+    onnx_cfg = OmegaConf.create(
+        {
+            "opset_version": 17,
+            "dynamo": False,
+            "dynamic_axes": {"input": {0: "configured_batch"}},
+        }
+    )
+
+    export_to_onnx(
+        model=torch.nn.Identity(),
+        input_sample=(torch.ones(2, 3),),
+        onnx_cfg=onnx_cfg,
+        input_param_names=["input"],
+        output_names_override=None,
+        dynamic_axes_override=dynamic_axes_override,
+        output_path=tmp_path / "model.onnx",
+    )
+
+    assert captured_kwargs["dynamic_axes"] == dynamic_axes_override
 
 
 def test_supports_export_stage_uses_export_spec_capabilities() -> None:

--- a/autoware_ml/utils/deploy.py
+++ b/autoware_ml/utils/deploy.py
@@ -46,6 +46,8 @@ class ExportSpec:
         args: Example positional inputs supplied during export.
         input_param_names: Names associated with the positional input tensors.
         output_names: Optional names associated with exported output tensors.
+        dynamic_axes: Optional legacy ONNX dynamic-axis mapping generated with
+            the export arguments. Used only when exporting with ``dynamo=False``.
         supported_stages: Export stages supported by this specification.
     """
 
@@ -53,6 +55,7 @@ class ExportSpec:
     args: tuple[Any, ...]
     input_param_names: list[str]
     output_names: list[str] | None = None
+    dynamic_axes: dict[str, dict[int, str]] | None = None
     supported_stages: frozenset[str] = frozenset({"onnx", "tensorrt"})
 
 
@@ -328,6 +331,7 @@ def export_to_onnx(
     onnx_cfg: DictConfig,
     input_param_names: list[str],
     output_names_override: list[str] | None,
+    dynamic_axes_override: dict[str, dict[int, str]] | None,
     output_path: Path,
 ) -> None:
     """Export a model to ONNX."""
@@ -339,7 +343,9 @@ def export_to_onnx(
     dynamo = onnx_cfg.get("dynamo", True)
     dynamic_shapes = build_dynamic_shapes(onnx_cfg, input_param_names) if dynamo else None
     dynamic_shapes = normalize_dynamic_shapes_for_model(model, dynamic_shapes) if dynamo else None
-    dynamic_axes = build_dynamic_axes(onnx_cfg) if not dynamo else None
+    dynamic_axes = None
+    if not dynamo:
+        dynamic_axes = dynamic_axes_override or build_dynamic_axes(onnx_cfg)
     input_names = list(onnx_cfg.get("input_names", input_param_names))
     output_names = list(output_names_override or onnx_cfg.get("output_names", ["output"]))
 


### PR DESCRIPTION
## Summary
- Add optional `ExportSpec.dynamic_axes` for legacy ONNX exports.
- Make deploy export prefer spec-generated dynamic axes over YAML dynamic axes when `dynamo=false`.
- Add a unit test covering the override behavior.

## Why
Some export modules generate their input contract in code. Letting the same export spec provide dynamic axes keeps generated input names and generated dynamic axes together, avoiding brittle duplicated YAML.

For example, PTv3 in PR #46 generates onnx inputs and dynamic axes dependent on the number of encoder stages, so a static YAML is brittle.

## Verification
- `pixi run --environment dev pytest autoware_ml/tests/utils/test_deploy.py -q`
- `pixi run --environment dev pre-commit run --files autoware_ml/utils/deploy.py autoware_ml/scripts/deploy.py autoware_ml/tests/utils/test_deploy.py`