### PR TITLE
feat(detection3d): data filtering & oriented gaussian

### DIFF
--- a/autoware_ml/configs/tasks/detection3d/ptv3/base.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/base.yaml
@@ -78,9 +78,6 @@ datamodule:
   test_ann_file: ${datamodule.data_root}/info/detection3d/t4dataset_j6gen2_base_infos_val.pkl
   class_names: ${class_names}
   name_mapping: ${name_mapping}
-  filter_attributes: ${detection_filter_attributes}
-  min_num_lidar_points: ${train_min_num_lidar_points}
-  use_valid_flag: ${detection_use_valid_flag}
   train_frame_sampling:
     repeat_sampling_factor: 0.30
     object_bev_range: ${point_cloud_bev_range}

--- a/autoware_ml/configs/tasks/detection3d/ptv3/base.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/base.yaml
@@ -26,6 +26,8 @@ head_voxel_size: ???
 train_min_num_lidar_points: 1
 train_object_min_num_points: 5
 eval_min_num_lidar_points: 1
+detection_filter_attributes: []
+detection_use_valid_flag: true
 
 head_out_size_factor: 1
 score_threshold: 0.1
@@ -35,6 +37,8 @@ nms_min_radius: 1.0
 train_sweeps_num: 1
 val_sweeps_num: 1
 
+merge_objects: [[truck, [truck, trailer]]]
+
 name_mapping:
   car: car
   emergency_vehicle: truck
@@ -42,8 +46,8 @@ name_mapping:
   tractor_unit: truck
   construction_vehicle: truck
   fire_truck: truck
-  semi_trailer: truck
-  trailer: truck
+  semi_trailer: trailer
+  trailer: trailer
   bus: bus
   bicycle: bicycle
   motorcycle: bicycle
@@ -74,6 +78,9 @@ datamodule:
   test_ann_file: ${datamodule.data_root}/info/detection3d/t4dataset_j6gen2_base_infos_val.pkl
   class_names: ${class_names}
   name_mapping: ${name_mapping}
+  filter_attributes: ${detection_filter_attributes}
+  min_num_lidar_points: ${train_min_num_lidar_points}
+  use_valid_flag: ${detection_use_valid_flag}
   train_frame_sampling:
     repeat_sampling_factor: 0.30
     object_bev_range: ${point_cloud_bev_range}
@@ -104,9 +111,14 @@ datamodule:
   train_transforms:
     _target_: autoware_ml.transforms.base.TransformsCompose
     pipeline:
+      - _target_: autoware_ml.transforms.boxes3d.merge.MergeObjects3D
+        merge_objects: ${merge_objects}
+        name_mapping: ${name_mapping}
       - _target_: autoware_ml.transforms.boxes3d.loading.LoadAnnotations3D
         name_mapping: ${name_mapping}
         min_num_lidar_points: ${train_min_num_lidar_points}
+        filter_attributes: ${detection_filter_attributes}
+        use_valid_flag: ${detection_use_valid_flag}
       - _target_: autoware_ml.transforms.point_cloud.sweeps.LoadPointsFromMultiSweeps
         sweeps_num: ${train_sweeps_num}
         load_dim: 5
@@ -140,9 +152,14 @@ datamodule:
   val_transforms:
     _target_: autoware_ml.transforms.base.TransformsCompose
     pipeline:
+      - _target_: autoware_ml.transforms.boxes3d.merge.MergeObjects3D
+        merge_objects: ${merge_objects}
+        name_mapping: ${name_mapping}
       - _target_: autoware_ml.transforms.boxes3d.loading.LoadAnnotations3D
         name_mapping: ${name_mapping}
         min_num_lidar_points: ${eval_min_num_lidar_points}
+        filter_attributes: ${detection_filter_attributes}
+        use_valid_flag: ${detection_use_valid_flag}
       - _target_: autoware_ml.transforms.point_cloud.sweeps.LoadPointsFromMultiSweeps
         sweeps_num: ${val_sweeps_num}
         load_dim: 5

--- a/autoware_ml/configs/tasks/detection3d/ptv3/centerhead_voxel005_102m_nuscenes.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/centerhead_voxel005_102m_nuscenes.yaml
@@ -17,6 +17,7 @@ class_names:
   - traffic_cone
 num_classes: 10
 name_mapping: null
+merge_objects: []
 
 grid_size: 0.05
 point_cloud_range: [-102.4, -102.4, -3.0, 102.4, 102.4, 5.0]

--- a/autoware_ml/configs/tasks/detection3d/ptv3/centerhead_voxel005_128m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/centerhead_voxel005_128m_t4dataset_j6gen2.yaml
@@ -11,6 +11,10 @@ point_cloud_bev_range: [-128.0, -128.0, 128.0, 128.0]
 bev_stride: 4
 bev_output_shape: [1280, 1280]
 head_voxel_size: [0.2, 0.2, 8.0]
+detection_filter_attributes:
+  - [bicycle, cycle_state.without_rider]
+  - [motorcycle, vehicle_state.parked]
+  - [motorcycle, motorcycle_state.without_rider]
 
 model:
   export_output_names: [heatmap, reg, height, dim, rot, vel]

--- a/autoware_ml/configs/tasks/detection3d/ptv3/centerhead_voxel012_122m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/centerhead_voxel012_122m_t4dataset_j6gen2.yaml
@@ -14,6 +14,10 @@ head_voxel_size: [0.96, 0.96, 8.0]
 
 train_sweeps_num: 1
 val_sweeps_num: 1
+detection_filter_attributes:
+  - [bicycle, cycle_state.without_rider]
+  - [motorcycle, vehicle_state.parked]
+  - [motorcycle, motorcycle_state.without_rider]
 
 datamodule:
   train_dataloader_cfg:

--- a/autoware_ml/configs/tasks/detection3d/ptv3/centerhead_voxel012_122m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/centerhead_voxel012_122m_t4dataset_j6gen2.yaml
@@ -20,6 +20,9 @@ detection_filter_attributes:
   - [motorcycle, motorcycle_state.without_rider]
 
 datamodule:
+  filter_attributes: ${detection_filter_attributes}
+  min_num_lidar_points: ${train_min_num_lidar_points}
+  use_valid_flag: ${detection_use_valid_flag}
   train_dataloader_cfg:
     batch_size: 16
     num_workers: 32

--- a/autoware_ml/configs/tasks/detection3d/ptv3/transhead_voxel005_102m_nuscenes.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/transhead_voxel005_102m_nuscenes.yaml
@@ -17,6 +17,7 @@ class_names:
   - traffic_cone
 num_classes: 10
 name_mapping: null
+merge_objects: []
 
 grid_size: 0.05
 point_cloud_range: [-102.4, -102.4, -3.0, 102.4, 102.4, 5.0]
@@ -79,6 +80,8 @@ model:
     hidden_channel: 128
     num_classes: ${num_classes}
     class_names: ${class_names}
+    dense_heatmap_pooling_classes:
+      [car, truck, construction_vehicle, bus, trailer, barrier, motorcycle, bicycle]
     num_decoder_layers: 1
     num_heads: 8
     feedforward_channels: 256
@@ -121,6 +124,7 @@ model:
     loss_cls_weight: 1.0
     loss_bbox_weight: 0.25
     loss_heatmap_weight: 1.0
+    heatmap_target: round
     heatmap_init_bias: -2.19
     nms_kernel_size: 3
     use_velocity: true

--- a/autoware_ml/configs/tasks/detection3d/ptv3/transhead_voxel005_128m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/transhead_voxel005_128m_t4dataset_j6gen2.yaml
@@ -19,6 +19,11 @@ detection_filter_attributes:
   - [motorcycle, vehicle_state.parked]
   - [motorcycle, motorcycle_state.without_rider]
 
+datamodule:
+  filter_attributes: ${detection_filter_attributes}
+  min_num_lidar_points: ${train_min_num_lidar_points}
+  use_valid_flag: ${detection_use_valid_flag}
+
 model:
   export_output_names:
     [

--- a/autoware_ml/configs/tasks/detection3d/ptv3/transhead_voxel005_128m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/transhead_voxel005_128m_t4dataset_j6gen2.yaml
@@ -14,6 +14,10 @@ head_voxel_size: [0.2, 0.2, 8.0]
 post_center_range: [-138.0, -138.0, -5.0, 138.0, 138.0, 12.0]
 code_weights: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.2, 0.2]
 num_proposals: 200
+detection_filter_attributes:
+  - [bicycle, cycle_state.without_rider]
+  - [motorcycle, vehicle_state.parked]
+  - [motorcycle, motorcycle_state.without_rider]
 
 model:
   export_output_names:
@@ -36,6 +40,7 @@ model:
     hidden_channel: 128
     num_classes: ${num_classes}
     class_names: ${class_names}
+    dense_heatmap_pooling_classes: [car, truck, bus, bicycle]
     num_decoder_layers: 1
     num_heads: 8
     feedforward_channels: 256
@@ -78,6 +83,7 @@ model:
     loss_cls_weight: 1.0
     loss_bbox_weight: 0.25
     loss_heatmap_weight: 1.0
+    heatmap_target: oriented
     heatmap_init_bias: -2.19
     nms_kernel_size: 3
     use_velocity: true

--- a/autoware_ml/configs/tasks/detection3d/ptv3/transhead_voxel012_122m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/transhead_voxel012_122m_t4dataset_j6gen2.yaml
@@ -13,10 +13,14 @@ bev_output_shape: [256, 256]
 head_voxel_size: [0.96, 0.96, 8.0]
 post_center_range: [-132.88, -132.88, -5.0, 132.88, 132.88, 12.0]
 code_weights: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.2, 0.2]
-num_proposals: 200
+num_proposals: 500
 
 train_sweeps_num: 1
 val_sweeps_num: 1
+detection_filter_attributes:
+  - [bicycle, cycle_state.without_rider]
+  - [motorcycle, vehicle_state.parked]
+  - [motorcycle, motorcycle_state.without_rider]
 
 datamodule:
   train_dataloader_cfg:
@@ -51,6 +55,7 @@ model:
     hidden_channel: 128
     num_classes: ${num_classes}
     class_names: ${class_names}
+    dense_heatmap_pooling_classes: [car, truck, bus, bicycle]
     num_decoder_layers: 1
     num_heads: 8
     feedforward_channels: 256
@@ -93,6 +98,7 @@ model:
     loss_cls_weight: 1.0
     loss_bbox_weight: 0.25
     loss_heatmap_weight: 1.0
+    heatmap_target: oriented
     heatmap_init_bias: -2.19
     nms_kernel_size: 3
     use_velocity: true

--- a/autoware_ml/configs/tasks/detection3d/ptv3/transhead_voxel012_122m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/transhead_voxel012_122m_t4dataset_j6gen2.yaml
@@ -23,6 +23,9 @@ detection_filter_attributes:
   - [motorcycle, motorcycle_state.without_rider]
 
 datamodule:
+  filter_attributes: ${detection_filter_attributes}
+  min_num_lidar_points: ${train_min_num_lidar_points}
+  use_valid_flag: ${detection_use_valid_flag}
   train_dataloader_cfg:
     batch_size: 16
     num_workers: 32

--- a/autoware_ml/datamodule/t4dataset/detection3d.py
+++ b/autoware_ml/datamodule/t4dataset/detection3d.py
@@ -37,6 +37,10 @@ from autoware_ml.datamodule.common.detection3d import (
     resolve_sweep_paths,
 )
 from autoware_ml.transforms.base import TransformsCompose
+from autoware_ml.transforms.boxes3d.annotations import (
+    normalize_filter_attributes,
+    resolve_detection_class,
+)
 
 
 @dataclass(frozen=True)
@@ -71,10 +75,14 @@ def compute_frame_sampling_weights(
     class_names: list[str],
     name_mapping: Mapping[str, str],
     frame_sampling: FrameSamplingConfig | None,
+    filter_attributes: list[list[str]] | None = None,
+    min_num_lidar_points: int = 0,
+    use_valid_flag: bool = True,
 ) -> list[float]:
     """Compute repeat-factor sampling weights for T4 detection samples."""
     if frame_sampling is None:
         return [1.0] * len(data_infos)
+    normalized_filter_attributes = normalize_filter_attributes(filter_attributes)
 
     sampling_categories = [*class_names, frame_sampling.low_pedestrian_category_name]
     category_frame_counts = {category: 0 for category in sampling_categories}
@@ -82,7 +90,15 @@ def compute_frame_sampling_weights(
     frame_categories = []
 
     for sample in data_infos:
-        categories = _sample_sampling_categories(sample, class_names, name_mapping, frame_sampling)
+        categories = _sample_sampling_categories(
+            sample,
+            class_names,
+            name_mapping,
+            frame_sampling,
+            normalized_filter_attributes,
+            min_num_lidar_points,
+            use_valid_flag,
+        )
         frame_categories.append(categories)
         for category, count in categories.items():
             if count <= 0:
@@ -122,16 +138,25 @@ def _sample_sampling_categories(
     class_names: list[str],
     name_mapping: Mapping[str, str],
     frame_sampling: FrameSamplingConfig,
+    filter_attributes: frozenset[tuple[str, str]],
+    min_num_lidar_points: int,
+    use_valid_flag: bool,
 ) -> dict[str, int]:
     """Return sampling category counts for one frame."""
     categories = {*class_names, frame_sampling.low_pedestrian_category_name}
     category_counts = {category: 0 for category in categories}
 
     for instance in sample.get("instances", []):
-        if not instance.get("bbox_3d_isvalid", True):
-            continue
-        mapped_name = _resolve_instance_name(instance, sample, name_mapping)
-        if mapped_name not in class_names:
+        mapped_name = resolve_detection_class(
+            instance,
+            class_names=class_names,
+            name_mapping=name_mapping,
+            label_to_category=sample.get("label_to_category"),
+            filter_attributes=filter_attributes,
+            min_num_lidar_points=min_num_lidar_points,
+            use_valid_flag=use_valid_flag,
+        )
+        if mapped_name is None:
             continue
         box = instance.get("bbox_3d")
         if box is None or not _box_center_in_bev_range(box, frame_sampling.object_bev_range):
@@ -143,19 +168,6 @@ def _sample_sampling_categories(
         category_counts[category] += 1
 
     return category_counts
-
-
-def _resolve_instance_name(
-    instance: Mapping[str, Any],
-    sample: Mapping[str, Any],
-    name_mapping: Mapping[str, str],
-) -> str:
-    """Map one raw instance label to a detector label."""
-    raw_name = instance.get("gt_nusc_name")
-    if raw_name is None:
-        label_to_category = sample.get("label_to_category", {})
-        raw_name = label_to_category.get(int(instance["bbox_label_3d"]), "")
-    return name_mapping.get(str(raw_name), str(raw_name))
 
 
 def _is_low_pedestrian(
@@ -190,6 +202,9 @@ class T4Detection3DDataset(Dataset):
         ann_file: str,
         class_names: list[str],
         name_mapping: Mapping[str, str],
+        filter_attributes: list[list[str]] | None = None,
+        min_num_lidar_points: int = 1,
+        use_valid_flag: bool = True,
         frame_sampling: FrameSamplingConfig | None = None,
         dataset_transforms: TransformsCompose | None = None,
     ) -> None:
@@ -200,6 +215,9 @@ class T4Detection3DDataset(Dataset):
             ann_file: Annotation file path.
             class_names: Ordered detector class names.
             name_mapping: Mapping from dataset labels to detector labels.
+            filter_attributes: Raw class-attribute pairs excluded from detection targets.
+            min_num_lidar_points: Minimum lidar points required for sampled boxes.
+            use_valid_flag: Whether ``bbox_3d_isvalid`` excludes sampled boxes.
             frame_sampling: Optional repeat-factor frame sampling settings.
             dataset_transforms: Optional dataset transform pipeline.
         """
@@ -217,6 +235,9 @@ class T4Detection3DDataset(Dataset):
             self.class_names,
             self.name_mapping,
             self.frame_sampling,
+            filter_attributes=filter_attributes,
+            min_num_lidar_points=min_num_lidar_points,
+            use_valid_flag=use_valid_flag,
         )
 
     def __len__(self) -> int:
@@ -263,6 +284,9 @@ class T4Detection3DDataModule(DataModule):
         test_ann_file: str,
         class_names: list[str],
         name_mapping: Mapping[str, str],
+        filter_attributes: list[list[str]] | None = None,
+        min_num_lidar_points: int = 1,
+        use_valid_flag: bool = True,
         train_frame_sampling: FrameSamplingConfig | Mapping[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
@@ -275,6 +299,9 @@ class T4Detection3DDataModule(DataModule):
             test_ann_file: Test annotation file path.
             class_names: Ordered detector class names.
             name_mapping: Mapping from dataset labels to detector labels.
+            filter_attributes: Raw class-attribute pairs excluded from detection targets.
+            min_num_lidar_points: Minimum lidar points required for sampled train boxes.
+            use_valid_flag: Whether ``bbox_3d_isvalid`` excludes sampled train boxes.
             train_frame_sampling: Optional repeat-factor frame sampling
                 settings applied only to the training split.
             **kwargs: Additional base datamodule configuration.
@@ -283,6 +310,9 @@ class T4Detection3DDataModule(DataModule):
         self.data_root = data_root
         self.class_names = class_names
         self.name_mapping = name_mapping
+        self.filter_attributes = filter_attributes
+        self.min_num_lidar_points = min_num_lidar_points
+        self.use_valid_flag = use_valid_flag
         self.train_frame_sampling = coerce_frame_sampling(train_frame_sampling)
 
         def resolve_ann_file(ann_file: str) -> str:
@@ -312,6 +342,9 @@ class T4Detection3DDataModule(DataModule):
             ann_file=self.ann_files[split],
             class_names=self.class_names,
             name_mapping=self.name_mapping,
+            filter_attributes=self.filter_attributes,
+            min_num_lidar_points=self.min_num_lidar_points,
+            use_valid_flag=self.use_valid_flag,
             frame_sampling=self.train_frame_sampling if split == "train" else None,
             dataset_transforms=dataset_transforms,
         )

--- a/autoware_ml/models/detection3d/heads/transfusion.py
+++ b/autoware_ml/models/detection3d/heads/transfusion.py
@@ -23,6 +23,7 @@ from autoware_ml.models.detection3d.task_modules.bbox_coders import TransFusionB
 from autoware_ml.models.detection3d.task_modules.heatmap import (
     circle_nms,
     draw_heatmap_gaussian,
+    draw_heatmap_gaussian_oriented,
     gaussian_radius,
 )
 
@@ -298,6 +299,7 @@ class TransFusionHead(nn.Module):
         post_max_size: int,
         nms_min_radius: float,
         class_names: Sequence[str] | None = None,
+        heatmap_target: str = "round",
         dense_heatmap_pooling_classes: Sequence[str | int] | None = None,
         nms_type: str | None = None,
         nms_groups: Sequence[dict[str, Any]] | None = None,
@@ -328,11 +330,18 @@ class TransFusionHead(nn.Module):
             code_weights: Weights applied to each regression channel.
             min_radius: Minimum heatmap Gaussian radius.
             gaussian_overlap: Required overlap for Gaussian radius computation.
+                Only used by the ``"round"`` heatmap target.
             score_threshold: Prediction score threshold used during decoding.
             post_max_size: Maximum number of predictions kept after NMS.
             nms_min_radius: Minimum center distance used by circle NMS.
             class_names: Optional ordered class names used to resolve config-friendly
                 class lists.
+            heatmap_target: Shape of the dense heatmap supervision. ``"round"``
+                (default) draws a circular Gaussian sized by ``gaussian_radius``.
+                ``"oriented"`` draws an elliptical Gaussian stretched along the box
+                length and rotated by the box yaw, so elongated objects such as a
+                tractor and trailer rig get one connected positive region instead of
+                a small blob in the low-density gap at the coupling.
             dense_heatmap_pooling_classes: Optional class names or class indices
                 that should use local max pooling before proposal selection.
             nms_type: Optional NMS type applied during prediction. Supported values
@@ -356,6 +365,9 @@ class TransFusionHead(nn.Module):
         self.code_weights = code_weights
         self.min_radius = min_radius
         self.gaussian_overlap = gaussian_overlap
+        if heatmap_target not in {"round", "oriented"}:
+            raise ValueError(f"Unsupported TransFusion heatmap_target: {heatmap_target!r}")
+        self.heatmap_target = heatmap_target
         self.score_threshold = score_threshold
         self.post_max_size = post_max_size
         self.nms_min_radius = nms_min_radius
@@ -706,15 +718,27 @@ class TransFusionHead(nn.Module):
                     continue
                 length_cells = box[3] / voxel_size[0] / self.out_size_factor
                 width_cells = box[4] / voxel_size[1] / self.out_size_factor
-                radius = max(
-                    self.min_radius,
-                    gaussian_radius(
-                        (width_cells.item(), length_cells.item()), self.gaussian_overlap
-                    ),
-                )
-                draw_heatmap_gaussian(
-                    heatmap[batch_index, int(label.item())], (int(center_x), int(center_y)), radius
-                )
+                if self.heatmap_target == "oriented":
+                    draw_heatmap_gaussian_oriented(
+                        heatmap[batch_index, int(label.item())],
+                        (int(center_x), int(center_y)),
+                        length_cells.item(),
+                        width_cells.item(),
+                        float(box[6].item()),
+                        min_sigma=self.min_radius / 3.0,
+                    )
+                else:
+                    radius = max(
+                        self.min_radius,
+                        gaussian_radius(
+                            (width_cells.item(), length_cells.item()), self.gaussian_overlap
+                        ),
+                    )
+                    draw_heatmap_gaussian(
+                        heatmap[batch_index, int(label.item())],
+                        (int(center_x), int(center_y)),
+                        radius,
+                    )
         return heatmap
 
     def get_targets(

--- a/autoware_ml/models/detection3d/task_modules/heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/heatmap.py
@@ -88,6 +88,69 @@ def draw_heatmap_gaussian(heatmap: torch.Tensor, center: tuple[int, int], radius
     torch.maximum(masked_heatmap, masked_gaussian, out=masked_heatmap)
 
 
+def draw_heatmap_gaussian_oriented(
+    heatmap: torch.Tensor,
+    center: tuple[int, int],
+    length_cells: float,
+    width_cells: float,
+    yaw: float,
+    min_sigma: float = 1.0,
+) -> None:
+    """Draw an oriented elliptical Gaussian blob on a dense heatmap in place.
+
+    Unlike :func:`draw_heatmap_gaussian`, the blob is stretched along the box
+    length and rotated by ``yaw``. Elongated objects (for example a tractor and
+    trailer rig) therefore receive a single connected positive region that
+    covers the whole body, instead of a small round blob at the geometric
+    center, which for a long rig falls in the low-density gap at the coupling.
+
+    Args:
+        heatmap: Heatmap updated in place.
+        center: Heatmap center as ``(x, y)`` in cells.
+        length_cells: Box length in heatmap cells (long axis).
+        width_cells: Box width in heatmap cells (short axis).
+        yaw: Box yaw in radians, measured from the heatmap x axis.
+        min_sigma: Lower bound on each Gaussian sigma in cells. The default
+            matches the effective sigma of a ``min_radius`` round blob.
+    """
+    sigma_length = max(length_cells / 6.0, min_sigma)
+    sigma_width = max(width_cells / 6.0, min_sigma)
+    radius = int(math.ceil(3.0 * max(sigma_length, sigma_width)))
+    if radius < 1:
+        return
+
+    device = heatmap.device
+    dtype = heatmap.dtype
+    coords = torch.arange(-radius, radius + 1, device=device, dtype=dtype)
+    offset_y, offset_x = torch.meshgrid(coords, coords, indexing="ij")
+    cos_yaw = math.cos(yaw)
+    sin_yaw = math.sin(yaw)
+    # Rotate grid offsets into the box frame: x_box is along the length axis.
+    x_box = offset_x * cos_yaw + offset_y * sin_yaw
+    y_box = -offset_x * sin_yaw + offset_y * cos_yaw
+    gaussian = torch.exp(
+        -(
+            x_box * x_box / (2 * sigma_length * sigma_length)
+            + y_box * y_box / (2 * sigma_width * sigma_width)
+        )
+    )
+    gaussian[gaussian < torch.finfo(dtype).eps * gaussian.max()] = 0
+
+    x_center, y_center = center
+    height, width = heatmap.shape
+    left, right = min(x_center, radius), min(width - x_center - 1, radius)
+    top, bottom = min(y_center, radius), min(height - y_center - 1, radius)
+    if left < 0 or right < 0 or top < 0 or bottom < 0:
+        return
+    masked_heatmap = heatmap[
+        y_center - top : y_center + bottom + 1, x_center - left : x_center + right + 1
+    ]
+    masked_gaussian = gaussian[
+        radius - top : radius + bottom + 1, radius - left : radius + right + 1
+    ]
+    torch.maximum(masked_heatmap, masked_gaussian, out=masked_heatmap)
+
+
 def circle_nms(
     boxes: torch.Tensor, scores: torch.Tensor, min_radius: float, post_max_size: int
 ) -> torch.Tensor:

--- a/autoware_ml/models/segmentation3d/backbones/ptv3.py
+++ b/autoware_ml/models/segmentation3d/backbones/ptv3.py
@@ -19,11 +19,11 @@ This module contains the reusable encoder-decoder blocks used by PTv3.
 
 from __future__ import annotations
 
-from copy import deepcopy
-from dataclasses import dataclass
 import importlib
 import math
 from collections.abc import Sequence
+from copy import deepcopy
+from dataclasses import dataclass
 from typing import Any
 
 import spconv.pytorch as spconv
@@ -33,9 +33,9 @@ from torch.onnx.operators import shape_as_tensor
 
 from autoware_ml.ops.indexing.operators import argsort
 from autoware_ml.ops.segment.segment_csr import segment_csr
+from autoware_ml.ops.spconv.sparse_conv import SubMConv3d as ExportableSubMConv3d
 from autoware_ml.utils.point_cloud.batching import offset_to_bincount
 from autoware_ml.utils.point_cloud.structures import Point
-from autoware_ml.ops.spconv.sparse_conv import SubMConv3d as ExportableSubMConv3d
 
 
 def load_flash_attn_module() -> Any:

--- a/autoware_ml/tests/datamodule/test_detection3d.py
+++ b/autoware_ml/tests/datamodule/test_detection3d.py
@@ -26,6 +26,7 @@ from autoware_ml.datamodule.t4dataset.detection3d import (
     FrameSamplingConfig,
     T4Detection3DDataModule,
     T4Detection3DDataset,
+    compute_frame_sampling_weights,
 )
 from autoware_ml.transforms.boxes3d.loading import LoadAnnotations3D
 
@@ -116,6 +117,7 @@ class TestT4Detection3DDataset:
                                 "bbox_3d_isvalid": True,
                                 "gt_nusc_name": "car",
                                 "bbox_3d": [0.0, 0.0, 0.0, 4.0, 1.8, 1.5, 0.0],
+                                "num_lidar_pts": 10,
                             }
                         ],
                     }
@@ -130,11 +132,13 @@ class TestT4Detection3DDataset:
                             "bbox_3d_isvalid": True,
                             "gt_nusc_name": "car",
                             "bbox_3d": [0.0, 0.0, 0.0, 4.0, 1.8, 1.5, 0.0],
+                            "num_lidar_pts": 10,
                         },
                         {
                             "bbox_3d_isvalid": True,
                             "gt_nusc_name": "pedestrian",
                             "bbox_3d": [1.0, 1.0, 0.0, 0.6, 0.6, 1.2, 0.0],
+                            "num_lidar_pts": 10,
                         },
                     ],
                 },
@@ -159,6 +163,107 @@ class TestT4Detection3DDataset:
         assert dataset.frame_weights[5] > dataset.frame_weights[0]
         assert np.isclose(dataset.frame_weights[5], 42**0.25)
 
+    def test_frame_sampling_weights_exclude_filtered_attributes(self) -> None:
+        data_infos = [
+            {
+                "instances": [
+                    {
+                        "gt_nusc_name": "car",
+                        "bbox_3d": [0.0, 0.0, 0.0, 4.0, 1.8, 1.5, 0.0],
+                        "num_lidar_pts": 10,
+                    }
+                ]
+            },
+            {
+                "instances": [
+                    {
+                        "gt_nusc_name": "car",
+                        "bbox_3d": [0.0, 0.0, 0.0, 4.0, 1.8, 1.5, 0.0],
+                        "num_lidar_pts": 10,
+                    },
+                    {
+                        "gt_nusc_name": "motorcycle",
+                        "gt_attrs": ["vehicle_state.parked"],
+                        "bbox_3d": [1.0, 1.0, 0.0, 1.8, 0.8, 1.2, 0.0],
+                        "num_lidar_pts": 10,
+                    },
+                ]
+            },
+        ]
+        frame_sampling = FrameSamplingConfig(
+            repeat_sampling_factor=1.0,
+            object_bev_range=[-10.0, -10.0, 10.0, 10.0],
+            low_pedestrian_height_threshold=1.5,
+            low_pedestrian_bev_range=[-5.0, -5.0, 5.0, 5.0],
+        )
+
+        weights = compute_frame_sampling_weights(
+            data_infos,
+            class_names=["car", "bicycle"],
+            name_mapping={"car": "car", "motorcycle": "bicycle"},
+            frame_sampling=frame_sampling,
+            filter_attributes=[["motorcycle", "vehicle_state.parked"]],
+            min_num_lidar_points=1,
+        )
+
+        assert weights == [1.0, 1.0]
+
+    def test_dataset_frame_sampling_uses_annotation_filter_policy(self, tmp_path) -> None:
+        ann_file = tmp_path / "infos.pkl"
+        data = {
+            "data_list": [
+                {
+                    "token": "car_only",
+                    "lidar_path": "a.bin",
+                    "lidar_points": {"num_pts_feats": 5},
+                    "instances": [
+                        {
+                            "gt_nusc_name": "car",
+                            "bbox_3d": [0.0, 0.0, 0.0, 4.0, 1.8, 1.5, 0.0],
+                            "num_lidar_pts": 10,
+                        }
+                    ],
+                },
+                {
+                    "token": "car_and_filtered_bicycle",
+                    "lidar_path": "b.bin",
+                    "lidar_points": {"num_pts_feats": 5},
+                    "instances": [
+                        {
+                            "gt_nusc_name": "car",
+                            "bbox_3d": [0.0, 0.0, 0.0, 4.0, 1.8, 1.5, 0.0],
+                            "num_lidar_pts": 10,
+                        },
+                        {
+                            "gt_nusc_name": "motorcycle",
+                            "gt_attrs": ["vehicle_state.parked"],
+                            "bbox_3d": [1.0, 1.0, 0.0, 1.8, 0.8, 1.2, 0.0],
+                            "num_lidar_pts": 10,
+                        },
+                    ],
+                },
+            ],
+        }
+        with open(ann_file, "wb") as file:
+            pickle.dump(data, file)
+
+        dataset = T4Detection3DDataset(
+            data_root=str(tmp_path),
+            ann_file=str(ann_file),
+            class_names=["car", "bicycle"],
+            name_mapping={"car": "car", "motorcycle": "bicycle"},
+            filter_attributes=[["motorcycle", "vehicle_state.parked"]],
+            min_num_lidar_points=1,
+            frame_sampling=FrameSamplingConfig(
+                repeat_sampling_factor=1.0,
+                object_bev_range=[-10.0, -10.0, 10.0, 10.0],
+                low_pedestrian_height_threshold=1.5,
+                low_pedestrian_bev_range=[-5.0, -5.0, 5.0, 5.0],
+            ),
+        )
+
+        assert dataset.frame_weights == [1.0, 1.0]
+
     def test_train_dataloader_uses_distributed_weighted_sampler(self, tmp_path) -> None:
         data_root = tmp_path / "t4dataset"
         info_root = data_root / "info" / "detection3d"
@@ -175,6 +280,7 @@ class TestT4Detection3DDataset:
                             "bbox_3d_isvalid": True,
                             "gt_nusc_name": "car",
                             "bbox_3d": [0.0, 0.0, 0.0, 4.0, 1.8, 1.5, 0.0],
+                            "num_lidar_pts": 10,
                         }
                     ],
                 }

--- a/autoware_ml/tests/models/test_detection3d_task_modules.py
+++ b/autoware_ml/tests/models/test_detection3d_task_modules.py
@@ -67,9 +67,7 @@ def test_transfusion_oriented_heatmap_target_runs_through_get_targets() -> None:
         "rot": torch.zeros((1, 2, 2), dtype=torch.float32),
         "vel": torch.zeros((1, 2, 2), dtype=torch.float32),
     }
-    gt_boxes = [
-        torch.tensor([[8.0, 8.0, 0.0, 12.0, 2.0, 1.5, 0.0, 0.0, 0.0]], dtype=torch.float32)
-    ]
+    gt_boxes = [torch.tensor([[8.0, 8.0, 0.0, 12.0, 2.0, 1.5, 0.0, 0.0, 0.0]], dtype=torch.float32)]
     gt_labels = [torch.tensor([0], dtype=torch.long)]
 
     targets = head.get_targets(gt_boxes, gt_labels, outputs)

--- a/autoware_ml/tests/models/test_detection3d_task_modules.py
+++ b/autoware_ml/tests/models/test_detection3d_task_modules.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import torch
 
+from autoware_ml.models.detection3d.heads.transfusion import TransFusionHead
 from autoware_ml.models.detection3d.task_modules.assigners import HungarianAssigner3D
 from autoware_ml.models.detection3d.task_modules.bbox_coders import TransFusionBBoxCoder
 from autoware_ml.models.detection3d.task_modules.match_costs import (
@@ -11,6 +12,71 @@ from autoware_ml.models.detection3d.task_modules.match_costs import (
     ClassificationCost,
     IoU3DCost,
 )
+
+
+def _build_transfusion_head(heatmap_target: str) -> TransFusionHead:
+    return TransFusionHead(
+        num_proposals=2,
+        auxiliary=False,
+        in_channels=4,
+        hidden_channel=8,
+        num_classes=1,
+        num_decoder_layers=1,
+        num_heads=1,
+        feedforward_channels=8,
+        common_heads={
+            "center": (2, 1),
+            "height": (1, 1),
+            "dim": (3, 1),
+            "rot": (2, 1),
+            "vel": (2, 1),
+        },
+        bbox_coder=TransFusionBBoxCoder(
+            pc_range=[0.0, 0.0],
+            out_size_factor=1,
+            voxel_size=[1.0, 1.0],
+            post_center_range=[-20.0, -20.0, -5.0, 20.0, 20.0, 5.0],
+            code_size=10,
+        ),
+        assigner=HungarianAssigner3D(
+            cls_cost=ClassificationCost(weight=0.15),
+            reg_cost=BBoxBEVL1Cost(weight=0.25),
+            iou_cost=IoU3DCost(weight=0.25),
+        ),
+        point_cloud_range=[0.0, 0.0, -2.0, 16.0, 16.0, 2.0],
+        voxel_size=[1.0, 1.0, 4.0],
+        out_size_factor=1,
+        code_weights=[1.0] * 8 + [0.2, 0.2],
+        min_radius=1,
+        gaussian_overlap=0.1,
+        score_threshold=0.1,
+        post_max_size=10,
+        nms_min_radius=1.0,
+        heatmap_target=heatmap_target,
+    )
+
+
+def test_transfusion_oriented_heatmap_target_runs_through_get_targets() -> None:
+    head = _build_transfusion_head(heatmap_target="oriented")
+    outputs = {
+        "dense_heatmap": torch.zeros((1, 1, 16, 16), dtype=torch.float32),
+        "heatmap": torch.zeros((1, 1, 2), dtype=torch.float32),
+        "center": torch.zeros((1, 2, 2), dtype=torch.float32),
+        "height": torch.zeros((1, 1, 2), dtype=torch.float32),
+        "dim": torch.zeros((1, 3, 2), dtype=torch.float32),
+        "rot": torch.zeros((1, 2, 2), dtype=torch.float32),
+        "vel": torch.zeros((1, 2, 2), dtype=torch.float32),
+    }
+    gt_boxes = [
+        torch.tensor([[8.0, 8.0, 0.0, 12.0, 2.0, 1.5, 0.0, 0.0, 0.0]], dtype=torch.float32)
+    ]
+    gt_labels = [torch.tensor([0], dtype=torch.long)]
+
+    targets = head.get_targets(gt_boxes, gt_labels, outputs)
+    heatmap = targets.heatmap[0, 0]
+
+    assert heatmap[8, 8] == torch.tensor(1.0)
+    assert heatmap[8, 12] > heatmap[12, 8]
 
 
 def test_transfusion_bbox_coder_encode_decode_round_trip_with_full_geometry_vectors() -> None:

--- a/autoware_ml/tests/transforms/test_boxes3d.py
+++ b/autoware_ml/tests/transforms/test_boxes3d.py
@@ -9,6 +9,7 @@ from autoware_ml.transforms.boxes3d.filters import (
     ObjectMinPointsFilter,
     ObjectNameFilter,
     ObjectRangeFilter,
+    ObjectRangeMinPointsFilter,
 )
 from autoware_ml.transforms.boxes3d.loading import LoadAnnotations3D
 
@@ -81,6 +82,43 @@ def test_object_min_points_filter_counts_points_inside_rotated_boxes() -> None:
     output = ObjectMinPointsFilter(min_num_points=2)(sample)
 
     assert output["gt_boxes"].shape == (1, 7)
+
+
+def test_object_range_min_points_filter_uses_distance_specific_threshold() -> None:
+    sample = {
+        "gt_boxes": np.array(
+            [
+                [10.0, 0.0, 0.0, 2.0, 2.0, 2.0, 0.0],
+                [70.0, 0.0, 0.0, 2.0, 2.0, 2.0, 0.0],
+            ],
+            dtype=np.float32,
+        ),
+        "gt_names": np.array(["car", "car"]),
+        "gt_labels": np.array([0, 0], dtype=np.int64),
+        "coord": np.array(
+            [
+                [10.0, 0.0, 0.0],
+                [10.1, 0.0, 0.0],
+                [10.2, 0.0, 0.0],
+                [10.3, 0.0, 0.0],
+                [70.0, 0.0, 0.0],
+                [70.1, 0.0, 0.0],
+                [70.2, 0.0, 0.0],
+            ],
+            dtype=np.float32,
+        ),
+    }
+
+    near_filtered = ObjectRangeMinPointsFilter(
+        range_radius=[0.0, 60.0],
+        min_num_points=5,
+    )(sample)
+    output = ObjectRangeMinPointsFilter(
+        range_radius=[60.0, 130.0],
+        min_num_points=3,
+    )(near_filtered)
+
+    assert output["gt_boxes"][:, 0].tolist() == [70.0]
 
 
 def test_load_annotations3d_builds_detection_targets() -> None:
@@ -180,3 +218,90 @@ def test_load_annotations3d_filters_by_min_lidar_points() -> None:
 def test_load_annotations3d_rejects_negative_min_lidar_points() -> None:
     with pytest.raises(ValueError, match="min_num_lidar_points"):
         LoadAnnotations3D(min_num_lidar_points=-1)
+
+
+def test_load_annotations3d_preserves_ignored_bbox_label() -> None:
+    sample = {
+        "class_names": ["bicycle"],
+        "label_to_category": {5: "bicycle"},
+        "instances": [
+            {
+                "bbox_3d": [1.0, 2.0, 3.0, 2.0, 1.0, 1.5, 0.0],
+                "bbox_label_3d": -1,
+                "gt_nusc_name": "bicycle",
+                "num_lidar_pts": 10,
+            }
+        ],
+    }
+
+    output = LoadAnnotations3D(name_mapping={"bicycle": "bicycle"})(sample)
+
+    assert output["gt_boxes"].shape == (0, 9)
+
+
+def test_load_annotations3d_can_match_awml_validity_policy() -> None:
+    sample = {
+        "class_names": ["car"],
+        "instances": [
+            {
+                "bbox_3d": [1.0, 2.0, 3.0, 2.0, 1.0, 1.5, 0.0],
+                "gt_nusc_name": "car",
+                "num_lidar_pts": 10,
+                "bbox_3d_isvalid": False,
+            }
+        ],
+    }
+
+    default_output = LoadAnnotations3D()(sample.copy())
+    awml_output = LoadAnnotations3D(use_valid_flag=False)(sample.copy())
+
+    assert default_output["gt_boxes"].shape == (0, 9)
+    assert awml_output["gt_boxes"].shape == (1, 9)
+
+
+def test_load_annotations3d_filters_raw_class_attributes() -> None:
+    sample = {
+        "class_names": ["bicycle"],
+        "instances": [
+            {
+                "bbox_3d": [1.0, 2.0, 3.0, 2.0, 1.0, 1.5, 0.0],
+                "gt_nusc_name": "motorcycle",
+                "gt_attrs": ["vehicle_state.parked"],
+                "num_lidar_pts": 10,
+            },
+            {
+                "bbox_3d": [2.0, 2.0, 3.0, 2.0, 1.0, 1.5, 0.0],
+                "gt_nusc_name": "motorcycle",
+                "gt_attrs": ["two_wheel_vehicle_state.without_rider"],
+                "num_lidar_pts": 10,
+            },
+        ],
+    }
+
+    output = LoadAnnotations3D(
+        name_mapping={"motorcycle": "bicycle"},
+        filter_attributes=[["motorcycle", "vehicle_state.parked"]],
+    )(sample)
+
+    assert output["gt_boxes"][:, 0].tolist() == [2.0]
+    assert output["gt_names"].tolist() == ["bicycle"]
+
+
+def test_load_annotations3d_rejects_disagreeing_source_label() -> None:
+    sample = {
+        "class_names": ["car", "pedestrian"],
+        "label_to_category": {0: "car"},
+        "instances": [
+            {
+                "bbox_3d": [1.0, 2.0, 3.0, 2.0, 1.0, 1.5, 0.0],
+                "bbox_label_3d": 0,
+                "gt_nusc_name": "pedestrian",
+                "num_lidar_pts": 10,
+            }
+        ],
+    }
+
+    with pytest.raises(ValueError, match="Annotation label disagreement"):
+        LoadAnnotations3D(
+            name_mapping={"car": "car", "pedestrian": "pedestrian"},
+        )(sample)

--- a/autoware_ml/tests/transforms/test_boxes3d.py
+++ b/autoware_ml/tests/transforms/test_boxes3d.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from autoware_ml.transforms.boxes3d.annotations import normalize_filter_attributes
 from autoware_ml.transforms.boxes3d.filters import (
     ObjectMinPointsFilter,
     ObjectNameFilter,
@@ -285,6 +286,14 @@ def test_load_annotations3d_filters_raw_class_attributes() -> None:
 
     assert output["gt_boxes"][:, 0].tolist() == [2.0]
     assert output["gt_names"].tolist() == ["bicycle"]
+
+
+def test_normalize_filter_attributes_rejects_invalid_entries() -> None:
+    with pytest.raises(ValueError, match="filter_attributes entries"):
+        normalize_filter_attributes([["bicycle"]])
+
+    with pytest.raises(TypeError, match="filter_attributes entries"):
+        normalize_filter_attributes(["bicycle"])
 
 
 def test_load_annotations3d_rejects_disagreeing_source_label() -> None:

--- a/autoware_ml/tests/transforms/test_merge_objects.py
+++ b/autoware_ml/tests/transforms/test_merge_objects.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+from omegaconf import OmegaConf
 import pytest
 
 from autoware_ml.transforms.boxes3d.merge import MergeObjects3D
@@ -106,9 +107,33 @@ def test_noop_without_rules() -> None:
     assert out["instances"] == instances
 
 
+def test_hydra_list_config_rules_do_not_require_truthiness() -> None:
+    transform = MergeObjects3D(
+        merge_objects=OmegaConf.create([["truck", ["truck", "trailer"]]]),
+        name_mapping=_NAME_MAPPING,
+    )
+
+    assert transform.merge_objects == [("truck", ["truck", "trailer"])]
+
+
 def test_invalid_merge_type_raises() -> None:
     with pytest.raises(ValueError, match="merge_type"):
         MergeObjects3D(merge_objects=[("truck", ["truck", "trailer"])], merge_type="bogus")
+
+
+def test_extend_longer_merges_center_z_and_height_from_box_faces() -> None:
+    out = _merge().transform(
+        {
+            "instances": [
+                _instance([0, 0, 1, 4, 2, 2, 0], "truck"),
+                _instance([1, 0, 3, 4, 2, 2, 0], "trailer"),
+            ]
+        }
+    )
+
+    _, _, center_z, _, _, height, _ = out["instances"][0]["bbox_3d"]
+    assert center_z == pytest.approx(2.0, abs=1e-6)
+    assert height == pytest.approx(4.0, abs=1e-6)
 
 
 def test_union_strategy_covers_both_boxes() -> None:
@@ -125,3 +150,18 @@ def test_union_strategy_covers_both_boxes() -> None:
     cx, _, _, dx, _, _, _ = out["instances"][0]["bbox_3d"]
     assert dx == pytest.approx(9.0, abs=1e-6)
     assert cx == pytest.approx(2.5, abs=1e-6)
+
+
+def test_union_strategy_merges_center_z_and_height_from_box_faces() -> None:
+    out = _merge(merge_type="union").transform(
+        {
+            "instances": [
+                _instance([0, 0, 1, 4, 2, 2, 0], "truck"),
+                _instance([1, 0, 3, 4, 2, 2, 0], "trailer"),
+            ]
+        }
+    )
+
+    _, _, center_z, _, _, height, _ = out["instances"][0]["bbox_3d"]
+    assert center_z == pytest.approx(2.0, abs=1e-6)
+    assert height == pytest.approx(4.0, abs=1e-6)

--- a/autoware_ml/tests/transforms/test_merge_objects.py
+++ b/autoware_ml/tests/transforms/test_merge_objects.py
@@ -1,0 +1,127 @@
+"""Tests for the MergeObjects3D transform (truck + trailer merging)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from autoware_ml.transforms.boxes3d.merge import MergeObjects3D
+
+_NAME_MAPPING = {
+    "truck": "truck",
+    "vehicle.truck": "truck",
+    "trailer": "trailer",
+    "vehicle.trailer": "trailer",
+    "semi_trailer": "trailer",
+}
+
+
+def _instance(bbox, name, num_pts=10, velocity=(0.0, 0.0), attrs=None):
+    return {
+        "bbox_3d": list(bbox),
+        "gt_nusc_name": name,
+        "num_lidar_pts": num_pts,
+        "velocity": list(velocity),
+        "gt_attrs": list(attrs or []),
+    }
+
+
+def _merge(merge_objects=(("truck", ["truck", "trailer"]),), **kwargs):
+    return MergeObjects3D(merge_objects=list(merge_objects), name_mapping=_NAME_MAPPING, **kwargs)
+
+
+def test_extend_longer_geometry_matches_reference() -> None:
+    # truck dx=4 at x=0, collinear trailer dx=4 at x=5 (1 m gap) -> one 9 m box.
+    transform = _merge()
+    out = transform.transform(
+        {
+            "instances": [
+                _instance([0, 0, 0, 4, 2, 2, 0], "truck", num_pts=10, velocity=(1.0, 0.0)),
+                _instance([5, 0, 0, 4, 2, 2, 0], "trailer", num_pts=5, velocity=(1.0, 0.0)),
+            ]
+        }
+    )
+    assert len(out["instances"]) == 1
+    merged = out["instances"][0]
+    assert merged["gt_nusc_name"] == "truck"
+    np.testing.assert_allclose(merged["bbox_3d"], [2.5, 0.0, 0.0, 9.0, 2.0, 2.0, 0.0], atol=1e-6)
+    assert merged["num_lidar_pts"] == 15
+    np.testing.assert_allclose(merged["velocity"], [1.0, 0.0])
+    assert "bbox_label_3d" not in merged
+
+
+def test_overlapping_pair_is_merged() -> None:
+    out = _merge().transform(
+        {
+            "instances": [
+                _instance([0, 0, 0, 4, 2, 2, 0], "truck"),
+                _instance([1, 0, 0, 4, 2, 2, 0], "vehicle.trailer"),  # overlaps the truck
+            ]
+        }
+    )
+    assert len(out["instances"]) == 1
+    assert out["instances"][0]["gt_nusc_name"] == "truck"
+
+
+def test_distant_trailer_is_not_merged() -> None:
+    # trailer back face (x=98) is far from truck front face (x=2): no merge.
+    out = _merge().transform(
+        {
+            "instances": [
+                _instance([0, 0, 0, 4, 2, 2, 0], "truck"),
+                _instance([100, 0, 0, 4, 2, 2, 0], "trailer"),
+            ]
+        }
+    )
+    assert len(out["instances"]) == 2
+    names = sorted(i["gt_nusc_name"] for i in out["instances"])
+    assert names == ["trailer", "truck"]
+
+
+def test_each_box_merges_at_most_once() -> None:
+    # one truck between two trailers -> only one merge consumes the truck.
+    out = _merge().transform(
+        {
+            "instances": [
+                _instance([5, 0, 0, 4, 2, 2, 0], "trailer"),
+                _instance([0, 0, 0, 4, 2, 2, 0], "truck"),
+                _instance([-5, 0, 0, 4, 2, 2, 0], "trailer"),
+            ]
+        }
+    )
+    merged = [i for i in out["instances"] if i["gt_nusc_name"] == "truck"]
+    leftover_trailers = [i for i in out["instances"] if i["gt_nusc_name"] == "trailer"]
+    assert len(merged) == 1
+    assert len(leftover_trailers) == 1
+
+
+def test_noop_without_rules() -> None:
+    instances = [
+        _instance([0, 0, 0, 4, 2, 2, 0], "truck"),
+        _instance([5, 0, 0, 4, 2, 2, 0], "trailer"),
+    ]
+    out = MergeObjects3D(merge_objects=None, name_mapping=_NAME_MAPPING).transform(
+        {"instances": list(instances)}
+    )
+    assert out["instances"] == instances
+
+
+def test_invalid_merge_type_raises() -> None:
+    with pytest.raises(ValueError, match="merge_type"):
+        MergeObjects3D(merge_objects=[("truck", ["truck", "trailer"])], merge_type="bogus")
+
+
+def test_union_strategy_covers_both_boxes() -> None:
+    out = _merge(merge_type="union").transform(
+        {
+            "instances": [
+                _instance([0, 0, 0, 4, 2, 2, 0], "truck"),
+                _instance([5, 0, 0, 4, 2, 2, 0], "trailer"),
+            ]
+        }
+    )
+    assert len(out["instances"]) == 1
+    # Union footprint spans from the truck back (x=-2) to the trailer front (x=7).
+    cx, _, _, dx, _, _, _ = out["instances"][0]["bbox_3d"]
+    assert dx == pytest.approx(9.0, abs=1e-6)
+    assert cx == pytest.approx(2.5, abs=1e-6)

--- a/autoware_ml/transforms/boxes3d/annotations.py
+++ b/autoware_ml/transforms/boxes3d/annotations.py
@@ -1,0 +1,112 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared 3D annotation interpretation helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Iterable, Mapping, Sequence
+from typing import Any
+
+FilterAttributeSet = frozenset[tuple[str, str]]
+
+
+def normalize_filter_attributes(
+    filter_attributes: Iterable[Sequence[str]] | None,
+) -> FilterAttributeSet:
+    """Normalize configured class-attribute exclusions for repeated lookup."""
+    if filter_attributes is None:
+        return frozenset()
+    return frozenset(
+        (str(class_name), str(attribute)) for class_name, attribute in filter_attributes
+    )
+
+
+def resolve_detection_class(
+    instance: Mapping[str, Any],
+    *,
+    class_names: Sequence[str],
+    name_mapping: Mapping[str, str | None] | None,
+    label_to_category: Mapping[int, str] | None = None,
+    filter_attributes: Collection[tuple[str, str]] | None = None,
+    min_num_lidar_points: int = 1,
+    use_valid_flag: bool = True,
+) -> str | None:
+    """Resolve one stored instance into a detector class or reject it."""
+    if "bbox_label_3d" in instance and int(instance["bbox_label_3d"]) < 0:
+        return None
+    if use_valid_flag and not bool(instance.get("bbox_3d_isvalid", True)):
+        return None
+
+    num_lidar_points = int(instance.get("num_lidar_pts", 0))
+    if num_lidar_points < min_num_lidar_points:
+        return None
+
+    raw_name = instance.get("gt_nusc_name")
+    stored_name = _resolve_stored_name(instance, label_to_category)
+    if raw_name is None:
+        raw_name = stored_name
+    if raw_name is None:
+        return None
+
+    raw_name = str(raw_name)
+    mapped_name = _map_name(raw_name, name_mapping)
+    if stored_name is not None:
+        mapped_stored_name = _map_name(stored_name, name_mapping)
+        if mapped_name != mapped_stored_name:
+            raise ValueError(
+                "Annotation label disagreement: "
+                f"gt_nusc_name={raw_name!r} maps to {mapped_name!r}, while "
+                f"bbox_label_3d maps to source class {stored_name!r} and target "
+                f"{mapped_stored_name!r}."
+            )
+
+    if mapped_name not in class_names:
+        return None
+    if _has_filtered_attribute(instance, raw_name, filter_attributes):
+        return None
+    return mapped_name
+
+
+def _resolve_stored_name(
+    instance: Mapping[str, Any],
+    label_to_category: Mapping[int, str] | None,
+) -> str | None:
+    """Decode ``bbox_label_3d`` through the annotation file's class table."""
+    if "bbox_label_3d" not in instance or label_to_category is None:
+        return None
+    label = int(instance["bbox_label_3d"])
+    if label not in label_to_category:
+        raise ValueError(f"bbox_label_3d={label} is absent from the annotation class table.")
+    return str(label_to_category[label])
+
+
+def _map_name(raw_name: str, name_mapping: Mapping[str, str | None] | None) -> str | None:
+    """Map a source class name into the configured detector taxonomy."""
+    if name_mapping is None:
+        return raw_name
+    mapped_name = name_mapping.get(raw_name, raw_name)
+    return str(mapped_name) if mapped_name is not None else None
+
+
+def _has_filtered_attribute(
+    instance: Mapping[str, Any],
+    raw_name: str,
+    filter_attributes: Collection[tuple[str, str]] | None,
+) -> bool:
+    """Return whether the raw class and attributes match an exclusion rule."""
+    if not filter_attributes:
+        return False
+    attributes = {str(attribute) for attribute in instance.get("gt_attrs", [])}
+    return any((raw_name, attribute) in filter_attributes for attribute in attributes)

--- a/autoware_ml/transforms/boxes3d/annotations.py
+++ b/autoware_ml/transforms/boxes3d/annotations.py
@@ -28,9 +28,22 @@ def normalize_filter_attributes(
     """Normalize configured class-attribute exclusions for repeated lookup."""
     if filter_attributes is None:
         return frozenset()
-    return frozenset(
-        (str(class_name), str(attribute)) for class_name, attribute in filter_attributes
-    )
+
+    normalized: list[tuple[str, str]] = []
+    for index, entry in enumerate(filter_attributes):
+        if isinstance(entry, str) or not isinstance(entry, Sequence):
+            raise TypeError(
+                "filter_attributes entries must be two-item sequences, "
+                f"got {type(entry).__name__} at index {index}."
+            )
+        if len(entry) != 2:
+            raise ValueError(
+                "filter_attributes entries must contain [class_name, attribute], "
+                f"got {list(entry)!r} at index {index}."
+            )
+        class_name, attribute = entry
+        normalized.append((str(class_name), str(attribute)))
+    return frozenset(normalized)
 
 
 def resolve_detection_class(

--- a/autoware_ml/transforms/boxes3d/filters.py
+++ b/autoware_ml/transforms/boxes3d/filters.py
@@ -205,3 +205,41 @@ class ObjectMinPointsFilter(BaseTransform):
         mask = counts >= self.min_num_points
         _filter_present_box_keys(input_dict, mask)
         return input_dict
+
+
+class ObjectRangeMinPointsFilter(BaseTransform):
+    """Remove boxes below a point-count threshold within a BEV radial interval."""
+
+    _required_keys = ["gt_names", "coord"]
+    _optional_keys = ["gt_boxes"]
+
+    def __init__(self, range_radius: Sequence[float], min_num_points: int) -> None:
+        if len(range_radius) != 2:
+            raise ValueError(f"range_radius must contain [min, max], got {range_radius}")
+        min_radius, max_radius = (float(value) for value in range_radius)
+        if min_radius < 0.0 or min_radius >= max_radius:
+            raise ValueError(f"Expected 0 <= min radius < max radius, got {range_radius}")
+        if min_num_points <= 0:
+            raise ValueError(f"min_num_points must be positive, got {min_num_points}")
+        self.min_radius = min_radius
+        self.max_radius = max_radius
+        self.min_num_points = min_num_points
+
+    def apply_defaults(self, input_dict: dict[str, Any]) -> None:
+        """No defaults needed because missing boxes make this transform a no-op."""
+        pass
+
+    def transform(self, input_dict: dict[str, Any]) -> dict[str, Any]:
+        if "gt_boxes" not in input_dict:
+            return input_dict
+
+        boxes = input_dict["gt_boxes"]
+        radii = np.linalg.norm(boxes[:, :2], axis=1)
+        in_range = (radii >= self.min_radius) & (radii < self.max_radius)
+        counts = _count_points_in_rotated_boxes(
+            np.asarray(input_dict["coord"], dtype=np.float32),
+            boxes,
+        )
+        mask = ~in_range | (counts >= self.min_num_points)
+        _filter_present_box_keys(input_dict, mask)
+        return input_dict

--- a/autoware_ml/transforms/boxes3d/loading.py
+++ b/autoware_ml/transforms/boxes3d/loading.py
@@ -16,12 +16,19 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from typing import Any
 
 import numpy as np
 
 from autoware_ml.transforms.base import BaseTransform
+from autoware_ml.transforms.boxes3d.annotations import (
+    normalize_filter_attributes,
+    resolve_detection_class,
+)
+
+logger = logging.getLogger(__name__)
 
 
 class LoadAnnotations3D(BaseTransform):
@@ -56,11 +63,15 @@ class LoadAnnotations3D(BaseTransform):
         self,
         name_mapping: Mapping[str, str | None] | None = None,
         min_num_lidar_points: int = 1,
+        filter_attributes: list[list[str]] | None = None,
+        use_valid_flag: bool = True,
     ) -> None:
         if min_num_lidar_points < 0:
             raise ValueError(f"min_num_lidar_points must be >= 0, got {min_num_lidar_points}")
         self.name_mapping = dict(name_mapping) if name_mapping is not None else None
         self.min_num_lidar_points = min_num_lidar_points
+        self.filter_attributes = normalize_filter_attributes(filter_attributes)
+        self.use_valid_flag = use_valid_flag
         self._validated_class_names: set[tuple[str, ...]] = set()
 
     def apply_defaults(self, input_dict: dict[str, Any]) -> None:
@@ -75,16 +86,19 @@ class LoadAnnotations3D(BaseTransform):
         gt_boxes, gt_names, gt_num_points = [], [], []
 
         for inst in instances:
-            if not inst.get("bbox_3d_isvalid", True):
-                continue
-            num_pts = inst.get("num_lidar_pts", 0)
-            if num_pts < self.min_num_lidar_points:
-                continue
-
-            canonical = self._resolve_canonical_name(inst, input_dict, canonical_list)
+            canonical = resolve_detection_class(
+                inst,
+                class_names=canonical_list,
+                name_mapping=self.name_mapping,
+                label_to_category=input_dict.get("label_to_category"),
+                filter_attributes=self.filter_attributes,
+                min_num_lidar_points=self.min_num_lidar_points,
+                use_valid_flag=self.use_valid_flag,
+            )
             if canonical is None:
                 continue
 
+            num_pts = int(inst.get("num_lidar_pts", 0))
             box = list(inst["bbox_3d"])  # 7 values: cx cy cz dx dy dz yaw
             vel = list(inst.get("velocity", [0.0, 0.0]))
             vel = [0.0 if not np.isfinite(v) else float(v) for v in vel]
@@ -109,51 +123,29 @@ class LoadAnnotations3D(BaseTransform):
         return input_dict
 
     def _validate_name_mapping_targets(self, class_names: list[str]) -> None:
-        """Validate mapping targets once for each distinct class-name set."""
+        """Log mapping targets dropped because they are not detector classes.
+
+        A ``name_mapping`` target absent from ``class_names`` is treated as an
+        intentional drop (the AWML convention, e.g. mapping ``trailer`` to the
+        non-target class ``trailer`` so standalone trailers are excluded). Such
+        boxes are dropped downstream by ``resolve_detection_class``; this only
+        surfaces them once per distinct class-name set.
+        """
         if self.name_mapping is None:
             return
         class_name_key = tuple(str(name) for name in class_names)
         if class_name_key in self._validated_class_names:
             return
+        self._validated_class_names.add(class_name_key)
 
-        unknown_targets = sorted(
+        dropped_targets = sorted(
             {
-                mapped_name
+                str(mapped_name)
                 for mapped_name in self.name_mapping.values()
                 if mapped_name is not None and str(mapped_name) not in class_name_key
             }
         )
-        if unknown_targets:
-            raise ValueError(
-                "name_mapping contains target class names not present in class_names: "
-                f"{unknown_targets}"
+        if dropped_targets:
+            logger.info(
+                "name_mapping targets not in class_names will be dropped: %s", dropped_targets
             )
-        self._validated_class_names.add(class_name_key)
-
-    def _resolve_canonical_name(
-        self,
-        instance: Mapping[str, Any],
-        input_dict: Mapping[str, Any],
-        class_names: list[str],
-    ) -> str | None:
-        """Resolve one raw annotation label to a canonical class name."""
-        raw_name = instance.get("gt_nusc_name")
-        if raw_name is None and "bbox_label_3d" in instance:
-            label_idx = int(instance["bbox_label_3d"])
-            label_to_category = input_dict.get("label_to_category", {})
-            raw_name = label_to_category.get(label_idx)
-            if raw_name is None and self.name_mapping is None:
-                if label_idx < 0 or label_idx >= len(class_names):
-                    return None
-                raw_name = class_names[label_idx]
-
-        if raw_name is None:
-            return None
-
-        raw_name = str(raw_name)
-        if self.name_mapping is not None:
-            canonical = self.name_mapping.get(raw_name)
-            return str(canonical) if canonical is not None else None
-        if raw_name not in class_names:
-            return None
-        return raw_name

--- a/autoware_ml/transforms/boxes3d/merge.py
+++ b/autoware_ml/transforms/boxes3d/merge.py
@@ -1,0 +1,311 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Merge spatially-coupled object annotations (e.g. truck + trailer).
+
+This transform reproduces the AWML info-generation behaviour where a sub-object
+(such as a trailer) that overlaps or sits next to its target object (a truck) is
+merged into a single, elongated target box. Unmatched sub-objects are left in
+place and subsequently dropped by ``LoadAnnotations3D`` when their mapped class
+is not in ``class_names`` - exactly as AWML's ``merge_objects`` + class filtering.
+
+It runs on the raw ``instances`` list, before ``LoadAnnotations3D``, so the
+sub-object class is still distinguishable from the target via ``name_mapping``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from math import pi
+from typing import Any
+
+import numpy as np
+from shapely import affinity
+from shapely.geometry import Polygon
+from shapely.ops import unary_union
+
+from autoware_ml.transforms.base import BaseTransform
+
+
+class MergeObjects3D(BaseTransform):
+    """Merge a sub-object box into a nearby target box into a single box.
+
+    For each ``(target, [primary, secondary])`` rule, every ``primary`` box is
+    matched against every ``secondary`` box; a pair that overlaps in BEV or whose
+    front/back face centers are within ``distance_threshold`` is merged into one
+    box labelled ``target``. Matching is greedy: each box participates in at most
+    one merge. Unmatched boxes are left untouched.
+
+    Required keys:
+        instances: List of raw annotation dicts with ``bbox_3d`` (7 values:
+            ``[cx, cy, cz, dx, dy, dz, yaw]``) and ``gt_nusc_name``.
+
+    Generated keys:
+        instances: Rewritten list with merged instances replacing matched pairs.
+    """
+
+    _required_keys = ["instances"]
+
+    def __init__(
+        self,
+        merge_objects: Sequence[tuple[str, Sequence[str]]] | None = None,
+        name_mapping: Mapping[str, str | None] | None = None,
+        distance_threshold: float = 2.0,
+        merge_type: str = "extend_longer",
+    ) -> None:
+        """Initialize the merge transform.
+
+        Args:
+            merge_objects: Rules ``(target, [primary_class, secondary_class])``
+                using canonical class names (post ``name_mapping``). For example
+                ``[("truck", ["truck", "trailer"])]``. ``None`` or empty disables
+                the transform.
+            name_mapping: Raw-to-canonical class-name mapping used to classify
+                instances. When ``None``, raw ``gt_nusc_name`` values are used
+                directly.
+            distance_threshold: Maximum front/back face-center distance in meters
+                for two boxes to be considered adjacent.
+            merge_type: Box merge strategy, ``"extend_longer"`` or ``"union"``.
+        """
+        if merge_type not in {"extend_longer", "union"}:
+            raise ValueError(f"merge_type must be 'extend_longer' or 'union', got {merge_type!r}.")
+        self.merge_objects = [
+            (str(target), [str(primary), str(secondary)])
+            for target, (primary, secondary) in (merge_objects or [])
+        ]
+        self.name_mapping = dict(name_mapping) if name_mapping is not None else None
+        self.distance_threshold = float(distance_threshold)
+        self.merge_type = merge_type
+
+    def transform(self, input_dict: dict[str, Any]) -> dict[str, Any]:
+        if not self.merge_objects:
+            return input_dict
+
+        instances = list(input_dict["instances"])
+        if not instances:
+            return input_dict
+
+        canonical = [self._canonical_name(inst) for inst in instances]
+        boxes = [np.asarray(inst["bbox_3d"], dtype=np.float64)[:7] for inst in instances]
+        merge_function = (
+            _merge_boxes_extend_longer if self.merge_type == "extend_longer" else _merge_boxes_union
+        )
+
+        consumed: set[int] = set()
+        merged_instances: list[dict[str, Any]] = []
+        for target, (primary, secondary) in self.merge_objects:
+            primary_indices = [i for i, name in enumerate(canonical) if name == primary]
+            secondary_indices = [i for i, name in enumerate(canonical) if name == secondary]
+            for i in primary_indices:
+                if i in consumed:
+                    continue
+                for j in secondary_indices:
+                    if j in consumed or i == j:
+                        continue
+                    if _boxes_overlap(boxes[i], boxes[j]) or _boxes_proximity(
+                        boxes[i], boxes[j], self.distance_threshold
+                    ):
+                        merged_instances.append(
+                            self._merge_instances(
+                                instances[i],
+                                instances[j],
+                                merge_function(boxes[i], boxes[j]),
+                                target,
+                            )
+                        )
+                        consumed.add(i)
+                        consumed.add(j)
+                        break
+
+        if not consumed:
+            return input_dict
+
+        survivors = [inst for idx, inst in enumerate(instances) if idx not in consumed]
+        input_dict["instances"] = merged_instances + survivors
+        return input_dict
+
+    def _canonical_name(self, instance: Mapping[str, Any]) -> str | None:
+        raw_name = instance.get("gt_nusc_name")
+        if raw_name is None:
+            return None
+        raw_name = str(raw_name)
+        if self.name_mapping is None:
+            return raw_name
+        mapped = self.name_mapping.get(raw_name, raw_name)
+        return str(mapped) if mapped is not None else None
+
+    @staticmethod
+    def _merge_instances(
+        primary: Mapping[str, Any],
+        secondary: Mapping[str, Any],
+        merged_box: list[float],
+        target: str,
+    ) -> dict[str, Any]:
+        """Build one merged instance from a matched primary/secondary pair."""
+        merged = dict(primary)
+        merged["bbox_3d"] = [float(value) for value in merged_box]
+        merged["gt_nusc_name"] = target
+        merged["num_lidar_pts"] = int(primary.get("num_lidar_pts", 0)) + int(
+            secondary.get("num_lidar_pts", 0)
+        )
+        primary_velocity = np.asarray(primary.get("velocity", [0.0, 0.0]), dtype=np.float64)
+        secondary_velocity = np.asarray(secondary.get("velocity", [0.0, 0.0]), dtype=np.float64)
+        merged["velocity"] = ((primary_velocity + secondary_velocity) / 2.0).tolist()
+        merged["gt_attrs"] = sorted(
+            set(primary.get("gt_attrs", [])) | set(secondary.get("gt_attrs", []))
+        )
+        merged["bbox_3d_isvalid"] = bool(primary.get("bbox_3d_isvalid", True)) and bool(
+            secondary.get("bbox_3d_isvalid", True)
+        )
+        # The merged box is a fresh target object; drop any stored per-box label
+        # so downstream resolution keys off the new gt_nusc_name.
+        merged.pop("bbox_label_3d", None)
+        return merged
+
+
+def _box_corners(box: np.ndarray) -> np.ndarray:
+    """Return the four BEV corners of an oriented box ``[x, y, z, dx, dy, dz, yaw]``."""
+    x, y, _, dx, dy, _, yaw = box
+    cos_yaw, sin_yaw = np.cos(yaw), np.sin(yaw)
+    half_dx, half_dy = dx / 2.0, dy / 2.0
+    return np.array(
+        [
+            [x - half_dx * cos_yaw + half_dy * sin_yaw, y - half_dx * sin_yaw - half_dy * cos_yaw],
+            [x + half_dx * cos_yaw + half_dy * sin_yaw, y + half_dx * sin_yaw - half_dy * cos_yaw],
+            [x + half_dx * cos_yaw - half_dy * sin_yaw, y + half_dx * sin_yaw + half_dy * cos_yaw],
+            [x - half_dx * cos_yaw - half_dy * sin_yaw, y - half_dx * sin_yaw + half_dy * cos_yaw],
+        ]
+    )
+
+
+def _boxes_overlap(box1: np.ndarray, box2: np.ndarray) -> bool:
+    """Return whether two boxes overlap in the BEV plane."""
+    return Polygon(_box_corners(box1)).intersects(Polygon(_box_corners(box2)))
+
+
+def _boxes_proximity(box1: np.ndarray, box2: np.ndarray, distance_threshold: float) -> bool:
+    """Return whether any front/back face centers are within the threshold."""
+
+    def face_centers(box: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        x, y, z, dx, _, _, yaw = box
+        front = np.array([x + dx / 2.0 * np.cos(yaw), y + dx / 2.0 * np.sin(yaw), z])
+        back = np.array([x - dx / 2.0 * np.cos(yaw), y - dx / 2.0 * np.sin(yaw), z])
+        return front, back
+
+    front1, back1 = face_centers(box1)
+    front2, back2 = face_centers(box2)
+    for a in (front1, back1):
+        for b in (front2, back2):
+            if np.linalg.norm(a - b) <= distance_threshold:
+                return True
+    return False
+
+
+def _merge_boxes_extend_longer(box1: np.ndarray, box2: np.ndarray) -> list[float]:
+    """Merge by elongating the larger box up to the far face of the smaller box."""
+
+    def get_box_faces(box: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray, float, float]:
+        x, y, _, dx, dy, _, yaw = box
+        center = np.array([x, y])
+        if dx >= dy:
+            face1 = np.array([x + (dx / 2) * np.cos(yaw), y + (dx / 2) * np.sin(yaw)])
+            face2 = np.array([x - (dx / 2) * np.cos(yaw), y - (dx / 2) * np.sin(yaw)])
+        else:
+            face1 = np.array(
+                [x + (dy / 2) * np.cos(yaw + pi / 2), y + (dy / 2) * np.sin(yaw + pi / 2)]
+            )
+            face2 = np.array(
+                [x - (dy / 2) * np.cos(yaw + pi / 2), y - (dy / 2) * np.sin(yaw + pi / 2)]
+            )
+        return center, face1, face2, dx, dy
+
+    c1, c1_f1, c1_f2, dx1, dy1 = get_box_faces(box1)
+    c2, c2_f1, c2_f2, dx2, dy2 = get_box_faces(box2)
+
+    if dx1 * dy1 >= dx2 * dy2:
+        larger_center, larger_f1, larger_f2, larger_dx, larger_dy, larger_box = (
+            c1,
+            c1_f1,
+            c1_f2,
+            dx1,
+            dy1,
+            box1,
+        )
+        smaller_center, smaller_f1, smaller_f2 = c2, c2_f1, c2_f2
+    else:
+        larger_center, larger_f1, larger_f2, larger_dx, larger_dy, larger_box = (
+            c2,
+            c2_f1,
+            c2_f2,
+            dx2,
+            dy2,
+            box2,
+        )
+        smaller_center, smaller_f1, smaller_f2 = c1, c1_f1, c1_f2
+
+    # Far face of the smaller box relative to the larger box center.
+    if np.linalg.norm(smaller_f1 - larger_center) > np.linalg.norm(smaller_f2 - larger_center):
+        selected_smaller_face = smaller_f1
+    else:
+        selected_smaller_face = smaller_f2
+
+    # Near face of the larger box relative to the smaller box center.
+    if np.linalg.norm(larger_f1 - smaller_center) < np.linalg.norm(larger_f2 - smaller_center):
+        selected_larger_face = larger_f1
+    else:
+        selected_larger_face = larger_f2
+
+    axis_vector = selected_larger_face - larger_center
+    axis_vector_normalized = axis_vector / np.linalg.norm(axis_vector)
+    to_smaller_box = selected_smaller_face - larger_center
+    projection_length = np.dot(to_smaller_box, axis_vector_normalized)
+    projection_point = larger_center + projection_length * axis_vector_normalized
+
+    elongation_vector = projection_point - selected_larger_face
+    elongation_length = np.linalg.norm(elongation_vector)
+
+    new_dx = larger_dx + elongation_length if larger_dx >= larger_dy else larger_dx
+    new_dy = larger_dy + elongation_length if larger_dy > larger_dx else larger_dy
+    new_center = larger_center + elongation_vector / 2.0
+
+    new_z = min(box1[2], box2[2])
+    new_dz = max(box1[2] + box1[5], box2[2] + box2[5]) - new_z
+    new_yaw = larger_box[6]
+
+    return [new_center[0], new_center[1], new_z, new_dx, new_dy, new_dz, new_yaw]
+
+
+def _merge_boxes_union(box1: np.ndarray, box2: np.ndarray) -> list[float]:
+    """Merge via the minimum rotated rectangle covering both BEV footprints."""
+
+    def shapely_box(box: np.ndarray) -> Polygon:
+        x, y, _, dx, dy, _, yaw = box
+        rect = Polygon([(-dx / 2, -dy / 2), (dx / 2, -dy / 2), (dx / 2, dy / 2), (-dx / 2, dy / 2)])
+        rect = affinity.rotate(rect, yaw, origin=(0, 0), use_radians=True)
+        return affinity.translate(rect, x, y)
+
+    merged = unary_union([shapely_box(box1), shapely_box(box2)]).minimum_rotated_rectangle
+    coords = list(merged.exterior.coords)[:-1]
+    new_x = sum(point[0] for point in coords) / 4.0
+    new_y = sum(point[1] for point in coords) / 4.0
+    edge1 = float(np.hypot(coords[0][0] - coords[1][0], coords[0][1] - coords[1][1]))
+    edge2 = float(np.hypot(coords[1][0] - coords[2][0], coords[1][1] - coords[2][1]))
+    new_dx, new_dy = max(edge1, edge2), min(edge1, edge2)
+    new_z = min(box1[2], box2[2])
+    new_dz = max(box1[2] + box1[5], box2[2] + box2[5]) - new_z
+    if edge1 >= edge2:
+        new_yaw = float(np.arctan2(coords[1][1] - coords[0][1], coords[1][0] - coords[0][0]))
+    else:
+        new_yaw = float(np.arctan2(coords[2][1] - coords[1][1], coords[2][0] - coords[1][0]))
+    return [new_x, new_y, new_z, new_dx, new_dy, new_dz, new_yaw]

--- a/autoware_ml/transforms/boxes3d/merge.py
+++ b/autoware_ml/transforms/boxes3d/merge.py
@@ -80,10 +80,32 @@ class MergeObjects3D(BaseTransform):
         """
         if merge_type not in {"extend_longer", "union"}:
             raise ValueError(f"merge_type must be 'extend_longer' or 'union', got {merge_type!r}.")
-        self.merge_objects = [
-            (str(target), [str(primary), str(secondary)])
-            for target, (primary, secondary) in (merge_objects or [])
-        ]
+        merge_rules = [] if merge_objects is None else merge_objects
+        self.merge_objects = []
+        for index, rule in enumerate(merge_rules):
+            if isinstance(rule, str) or not isinstance(rule, Sequence):
+                raise TypeError(
+                    "merge_objects entries must be two-item sequences, "
+                    f"got {type(rule).__name__} at index {index}."
+                )
+            if len(rule) != 2:
+                raise ValueError(
+                    "merge_objects entries must contain [target, [primary, secondary]], "
+                    f"got {list(rule)!r} at index {index}."
+                )
+            target, sources = rule
+            if isinstance(sources, str) or not isinstance(sources, Sequence):
+                raise TypeError(
+                    "merge_objects sources must be two-item sequences, "
+                    f"got {type(sources).__name__} at index {index}."
+                )
+            if len(sources) != 2:
+                raise ValueError(
+                    "merge_objects sources must contain [primary, secondary], "
+                    f"got {sources!r} at index {index}."
+                )
+            primary, secondary = sources
+            self.merge_objects.append((str(target), [str(primary), str(secondary)]))
         self.name_mapping = dict(name_mapping) if name_mapping is not None else None
         self.distance_threshold = float(distance_threshold)
         self.merge_type = merge_type
@@ -279,8 +301,7 @@ def _merge_boxes_extend_longer(box1: np.ndarray, box2: np.ndarray) -> list[float
     new_dy = larger_dy + elongation_length if larger_dy > larger_dx else larger_dy
     new_center = larger_center + elongation_vector / 2.0
 
-    new_z = min(box1[2], box2[2])
-    new_dz = max(box1[2] + box1[5], box2[2] + box2[5]) - new_z
+    new_z, new_dz = _merge_center_z_and_height(box1, box2)
     new_yaw = larger_box[6]
 
     return [new_center[0], new_center[1], new_z, new_dx, new_dy, new_dz, new_yaw]
@@ -302,10 +323,18 @@ def _merge_boxes_union(box1: np.ndarray, box2: np.ndarray) -> list[float]:
     edge1 = float(np.hypot(coords[0][0] - coords[1][0], coords[0][1] - coords[1][1]))
     edge2 = float(np.hypot(coords[1][0] - coords[2][0], coords[1][1] - coords[2][1]))
     new_dx, new_dy = max(edge1, edge2), min(edge1, edge2)
-    new_z = min(box1[2], box2[2])
-    new_dz = max(box1[2] + box1[5], box2[2] + box2[5]) - new_z
+    new_z, new_dz = _merge_center_z_and_height(box1, box2)
     if edge1 >= edge2:
         new_yaw = float(np.arctan2(coords[1][1] - coords[0][1], coords[1][0] - coords[0][0]))
     else:
         new_yaw = float(np.arctan2(coords[2][1] - coords[1][1], coords[2][0] - coords[1][0]))
     return [new_x, new_y, new_z, new_dx, new_dy, new_dz, new_yaw]
+
+
+def _merge_center_z_and_height(box1: np.ndarray, box2: np.ndarray) -> tuple[float, float]:
+    """Return center z and height spanning two center-based boxes."""
+    bottom = min(box1[2] - box1[5] / 2.0, box2[2] - box2[5] / 2.0)
+    top = max(box1[2] + box1[5] / 2.0, box2[2] + box2[5] / 2.0)
+    height = top - bottom
+    center_z = bottom + height / 2.0
+    return float(center_z), float(height)


### PR DESCRIPTION
## Summary

- Add shared detection annotation resolution for class mapping, valid-flag filtering, lidar-point filtering, and raw class/attribute filtering.
- Pass detection filtering options through `T4Detection3DDataModule`, `T4Detection3DDataset`, frame sampling, and `LoadAnnotations3D`.
- Add `MergeObjects3D` to merge coupled objects such as truck + trailer before annotation loading.
- Update PTv3 detection base config to use merge rules, trailer-aware name mapping, datamodule filtering args, and `LoadAnnotations3D` filtering args.
- Add raw attribute filters to T4 PTv3 detection configs for bicycles/motorcycles without riders and parked motorcycles.
- Disable merge rules for nuScenes PTv3 configs where trailer merging is not needed.
- Add oriented elliptical Gaussian heatmap targets to TransFusion and expose `heatmap_target`.
- Enable oriented heatmap targets and dense heatmap pooling classes in PTv3 TransFusion T4 configs.
- Add dense heatmap pooling classes to the PTv3 TransFusion nuScenes config.
- Increase `num_proposals` to 500 for `transhead_voxel012_122m_t4dataset_j6gen2`.
- Add object point-count filters, including radial range + minimum point filtering.
- Add tests for T4 detection filtering/frame sampling, annotation loading/filtering, object point filters, and merge-object behavior.

## Related Issues

<!-- Link related issues or feature requests -->

## Checklist

- [ ] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [ ] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

## Additional Notes

## Additional Log and Media

<!-- Any additional logs or information. -->
