### PR TITLE
feat(configs): shared dataset configs

### DIFF
--- a/autoware_ml/configs/datasets/nuscenes/base.yaml
+++ b/autoware_ml/configs/datasets/nuscenes/base.yaml
@@ -1,0 +1,3 @@
+# @package nuscenes
+
+data_root: ${oc.env:AUTOWARE_ML_DATA_PATH}/nuscenes

--- a/autoware_ml/configs/datasets/nuscenes/camera.yaml
+++ b/autoware_ml/configs/datasets/nuscenes/camera.yaml
@@ -1,0 +1,13 @@
+# @package nuscenes.camera
+
+defaults:
+  - /datasets/nuscenes/base
+  - _self_
+
+camera_order:
+  - CAM_FRONT
+  - CAM_FRONT_RIGHT
+  - CAM_FRONT_LEFT
+  - CAM_BACK
+  - CAM_BACK_LEFT
+  - CAM_BACK_RIGHT

--- a/autoware_ml/configs/datasets/nuscenes/detection3d.yaml
+++ b/autoware_ml/configs/datasets/nuscenes/detection3d.yaml
@@ -27,8 +27,6 @@ name_mapping:
 merge_objects: [[truck, [truck, trailer]]]
 filter_attributes: []
 use_valid_flag: true
-train_min_num_lidar_points: 1
-eval_min_num_lidar_points: 1
 eval_class_range:
   car: 50.0
   truck: 50.0

--- a/autoware_ml/configs/datasets/nuscenes/detection3d.yaml
+++ b/autoware_ml/configs/datasets/nuscenes/detection3d.yaml
@@ -1,0 +1,53 @@
+# @package nuscenes.detection3d
+
+defaults:
+  - /datasets/nuscenes/base
+  - _self_
+
+class_names:
+  - car
+  - truck
+  - bus
+  - bicycle
+  - pedestrian
+  - traffic_cone
+  - barrier
+num_classes: 7
+name_mapping:
+  car: car
+  truck: truck
+  construction_vehicle: truck
+  trailer: trailer
+  bus: bus
+  motorcycle: bicycle
+  bicycle: bicycle
+  pedestrian: pedestrian
+  traffic_cone: traffic_cone
+  barrier: barrier
+merge_objects: [[truck, [truck, trailer]]]
+filter_attributes: []
+use_valid_flag: true
+train_min_num_lidar_points: 1
+eval_min_num_lidar_points: 1
+eval_class_range:
+  car: 50.0
+  truck: 50.0
+  bus: 50.0
+  bicycle: 50.0
+  pedestrian: 50.0
+  traffic_cone: 50.0
+  barrier: 50.0
+metric_ranges:
+  - { _target_: autoware_ml.metrics.base.MetricRange, name: 0-50m, min_distance: 0.0, max_distance: 50.0 }
+metrics:
+  - _target_: autoware_ml.metrics.detection3d.suite.Detection3DMetricSuite
+    components:
+      - { _target_: autoware_ml.metrics.detection3d.mean_ap.MeanAP, stages: [val, test] }
+      - { _target_: autoware_ml.metrics.detection3d.heading_ap.HeadingAP, stages: [test] }
+      - { _target_: autoware_ml.metrics.detection3d.nds.Nds, stages: [test] }
+      - { _target_: autoware_ml.metrics.detection3d.tp_errors.TpErrors, stages: [test] }
+    class_names: ${nuscenes.detection3d.class_names}
+    thresholds: [0.5, 1.0, 2.0, 4.0]
+    min_num_points: 0
+    eval_class_range: ${nuscenes.detection3d.eval_class_range}
+    ranges: ${nuscenes.detection3d.metric_ranges}

--- a/autoware_ml/configs/datasets/nuscenes/lidar.yaml
+++ b/autoware_ml/configs/datasets/nuscenes/lidar.yaml
@@ -1,0 +1,5 @@
+# @package nuscenes.lidar
+
+defaults:
+  - /datasets/nuscenes/base
+  - _self_

--- a/autoware_ml/configs/datasets/nuscenes/segmentation3d.yaml
+++ b/autoware_ml/configs/datasets/nuscenes/segmentation3d.yaml
@@ -9,7 +9,7 @@ num_classes: 15
 max_label: 31
 seg_label_mapping:
   0: 14   # noise -> noise
-  1: ${ignore_index}   # animal
+  1: ${nuscenes.segmentation3d.ignore_index}   # animal
   2: 4    # pedestrian.adult -> pedestrian
   3: 4    # pedestrian.child -> pedestrian
   4: 4    # pedestrian.construction_worker -> pedestrian
@@ -21,7 +21,7 @@ seg_label_mapping:
   10: 7   # debris -> debris
   11: 7   # pushable_pullable -> debris
   12: 5   # trafficcone -> traffic_cone
-  13: ${ignore_index}   # bicycle_rack
+  13: ${nuscenes.segmentation3d.ignore_index}   # bicycle_rack
   14: 3   # bicycle -> bicycle
   15: 2   # bus.bendy -> bus
   16: 2   # bus.rigid -> bus
@@ -39,7 +39,7 @@ seg_label_mapping:
   28: 11  # manmade -> manmade
   29: 13  # static.other -> other_stuff
   30: 10  # vegetation -> vegetation
-  31: ${ignore_index}   # ego
+  31: ${nuscenes.segmentation3d.ignore_index}   # ego
 metrics:
   - _target_: autoware_ml.metrics.segmentation3d.suite.Segmentation3DMetricSuite
     components:
@@ -47,7 +47,7 @@ metrics:
       - { _target_: autoware_ml.metrics.segmentation3d.accuracy.Accuracy, stages: [val, test] }
       - { _target_: autoware_ml.metrics.segmentation3d.precision_recall_f1.PrecisionRecallF1, stages: [val, test] }
     num_classes: ${nuscenes.segmentation3d.num_classes}
-    ignore_index: ${ignore_index}
+    ignore_index: ${nuscenes.segmentation3d.ignore_index}
     class_names:
       - car
       - truck

--- a/autoware_ml/configs/datasets/nuscenes/segmentation3d.yaml
+++ b/autoware_ml/configs/datasets/nuscenes/segmentation3d.yaml
@@ -1,0 +1,71 @@
+# @package nuscenes.segmentation3d
+
+defaults:
+  - /datasets/nuscenes/base
+  - _self_
+
+ignore_index: -1
+num_classes: 15
+max_label: 31
+seg_label_mapping:
+  0: 14   # noise -> noise
+  1: ${ignore_index}   # animal
+  2: 4    # pedestrian.adult -> pedestrian
+  3: 4    # pedestrian.child -> pedestrian
+  4: 4    # pedestrian.construction_worker -> pedestrian
+  5: 4    # pedestrian.personal_mobility -> pedestrian
+  6: 4    # pedestrian.police_officer -> pedestrian
+  7: 4    # pedestrian.stroller -> pedestrian
+  8: 4    # pedestrian.wheelchair -> pedestrian
+  9: 6    # barrier -> barrier
+  10: 7   # debris -> debris
+  11: 7   # pushable_pullable -> debris
+  12: 5   # trafficcone -> traffic_cone
+  13: ${ignore_index}   # bicycle_rack
+  14: 3   # bicycle -> bicycle
+  15: 2   # bus.bendy -> bus
+  16: 2   # bus.rigid -> bus
+  17: 0   # car -> car
+  18: 1   # construction_vehicle -> truck
+  19: 0   # ambulance -> car
+  20: 0   # police -> car
+  21: 3   # motorcycle -> bicycle
+  22: 1   # trailer -> truck
+  23: 1   # truck -> truck
+  24: 8   # driveable_surface -> drivable_surface
+  25: 9   # flat.other -> other_flat_surface
+  26: 9   # sidewalk -> other_flat_surface
+  27: 9   # terrain -> other_flat_surface
+  28: 11  # manmade -> manmade
+  29: 13  # static.other -> other_stuff
+  30: 10  # vegetation -> vegetation
+  31: ${ignore_index}   # ego
+metrics:
+  - _target_: autoware_ml.metrics.segmentation3d.suite.Segmentation3DMetricSuite
+    components:
+      - { _target_: autoware_ml.metrics.segmentation3d.iou.IoU, stages: [val, test] }
+      - { _target_: autoware_ml.metrics.segmentation3d.accuracy.Accuracy, stages: [val, test] }
+      - { _target_: autoware_ml.metrics.segmentation3d.precision_recall_f1.PrecisionRecallF1, stages: [val, test] }
+    num_classes: ${nuscenes.segmentation3d.num_classes}
+    ignore_index: ${ignore_index}
+    class_names:
+      - car
+      - truck
+      - bus
+      - bicycle
+      - pedestrian
+      - traffic_cone
+      - barrier
+      - debris
+      - drivable_surface
+      - other_flat_surface
+      - vegetation
+      - manmade
+      - vertical_thin
+      - other_stuff
+      - noise
+    ranges:
+      - { _target_: autoware_ml.metrics.base.MetricRange, name: 0-50m, min_distance: 0.0, max_distance: 50.0 }
+      - { _target_: autoware_ml.metrics.base.MetricRange, name: 50-90m, min_distance: 50.0, max_distance: 90.0 }
+      - { _target_: autoware_ml.metrics.base.MetricRange, name: 90-121m, min_distance: 90.0, max_distance: 121.0 }
+      - { _target_: autoware_ml.metrics.base.MetricRange, name: 0-121m, min_distance: 0.0, max_distance: 121.0 }

--- a/autoware_ml/configs/datasets/t4dataset/base.yaml
+++ b/autoware_ml/configs/datasets/t4dataset/base.yaml
@@ -1,0 +1,3 @@
+# @package t4dataset
+
+data_root: ${oc.env:AUTOWARE_ML_DATA_PATH}/t4dataset

--- a/autoware_ml/configs/datasets/t4dataset/camera.yaml
+++ b/autoware_ml/configs/datasets/t4dataset/camera.yaml
@@ -1,0 +1,12 @@
+# @package t4dataset.camera
+
+defaults:
+  - /datasets/t4dataset/base
+  - _self_
+
+camera_order:
+  - CAM_FRONT
+  - CAM_FRONT_LEFT
+  - CAM_BACK_LEFT
+  - CAM_FRONT_RIGHT
+  - CAM_BACK_RIGHT

--- a/autoware_ml/configs/datasets/t4dataset/detection3d.yaml
+++ b/autoware_ml/configs/datasets/t4dataset/detection3d.yaml
@@ -78,8 +78,8 @@ filter_attributes:
   - [motorcycle, motorcycle_state.without_rider]
 merge_objects: [[truck, [truck, trailer]]]
 use_valid_flag: true
-train_min_num_lidar_points: 1
-eval_min_num_lidar_points: 1
+train_min_points_near: 2
+train_min_points_far: 1
 eval_class_range:
   car: 121.0
   truck: 121.0

--- a/autoware_ml/configs/datasets/t4dataset/detection3d.yaml
+++ b/autoware_ml/configs/datasets/t4dataset/detection3d.yaml
@@ -1,0 +1,107 @@
+# @package t4dataset.detection3d
+
+defaults:
+  - /datasets/t4dataset/base
+  - _self_
+
+class_names:
+  - car
+  - truck
+  - bus
+  - bicycle
+  - pedestrian
+  - traffic_cone
+  - barrier
+num_classes: 7
+name_mapping:
+  car: car
+  vehicle.car: car
+  "vehicle.emergency (ambulance & police)": car
+  ambulance: car
+  vehicle.ambulance: car
+  police_car: car
+  vehicle.police: car
+  forklift: car
+  kart: car
+  other_vehicle: car
+  truck: truck
+  vehicle.truck: truck
+  fire_truck: truck
+  vehicle.fire: truck
+  trailer: trailer
+  vehicle.trailer: trailer
+  semi_trailer: trailer
+  tractor_unit: truck
+  construction_vehicle: truck
+  vehicle.construction: truck
+  bus: bus
+  vehicle.bus: bus
+  "vehicle.bus (bendy & rigid)": bus
+  motorcycle: bicycle
+  vehicle.motorcycle: bicycle
+  bicycle: bicycle
+  vehicle.bicycle: bicycle
+  pedestrian: pedestrian
+  pedestrian.adult: pedestrian
+  pedestrian.child: pedestrian
+  other_pedestrian: pedestrian
+  police_officer: pedestrian
+  pedestrian.police_officer: pedestrian
+  construction_worker: pedestrian
+  pedestrian.construction_worker: pedestrian
+  personal_mobility: pedestrian
+  pedestrian.personal_mobility: pedestrian
+  wheelchair: pedestrian
+  pedestrian.wheelchair: pedestrian
+  stroller: pedestrian
+  pedestrian.stroller: pedestrian
+  barrier: barrier
+  movable_object.barrier: barrier
+  movable_object.debris: barrier
+  movable_object.pushable_pullable: barrier
+  traffic_cone: traffic_cone
+  trafficcone: traffic_cone
+  movable_object.traffic_cone: traffic_cone
+  movable_object.trafficcone: traffic_cone
+filter_attributes:
+  - [vehicle.bicycle, vehicle_state.parked]
+  - [vehicle.bicycle, cycle_state.without_rider]
+  - [vehicle.bicycle, motorcycle_state.without_rider]
+  - [vehicle.motorcycle, vehicle_state.parked]
+  - [vehicle.motorcycle, cycle_state.without_rider]
+  - [vehicle.motorcycle, motorcycle_state.without_rider]
+  - [bicycle, vehicle_state.parked]
+  - [bicycle, cycle_state.without_rider]
+  - [bicycle, motorcycle_state.without_rider]
+  - [motorcycle, vehicle_state.parked]
+  - [motorcycle, cycle_state.without_rider]
+  - [motorcycle, motorcycle_state.without_rider]
+merge_objects: [[truck, [truck, trailer]]]
+use_valid_flag: true
+train_min_num_lidar_points: 1
+eval_min_num_lidar_points: 1
+eval_class_range:
+  car: 121.0
+  truck: 121.0
+  bus: 121.0
+  bicycle: 121.0
+  pedestrian: 121.0
+  traffic_cone: 121.0
+  barrier: 121.0
+metric_ranges:
+  - { _target_: autoware_ml.metrics.base.MetricRange, name: 0-50m, min_distance: 0.0, max_distance: 50.0 }
+  - { _target_: autoware_ml.metrics.base.MetricRange, name: 50-90m, min_distance: 50.0, max_distance: 90.0 }
+  - { _target_: autoware_ml.metrics.base.MetricRange, name: 90-121m, min_distance: 90.0, max_distance: 121.0 }
+  - { _target_: autoware_ml.metrics.base.MetricRange, name: 0-121m, min_distance: 0.0, max_distance: 121.0 }
+metrics:
+  - _target_: autoware_ml.metrics.detection3d.suite.Detection3DMetricSuite
+    components:
+      - { _target_: autoware_ml.metrics.detection3d.mean_ap.MeanAP, stages: [val, test] }
+      - { _target_: autoware_ml.metrics.detection3d.heading_ap.HeadingAP, stages: [test] }
+      - { _target_: autoware_ml.metrics.detection3d.nds.Nds, stages: [test] }
+      - { _target_: autoware_ml.metrics.detection3d.tp_errors.TpErrors, stages: [test] }
+    class_names: ${t4dataset.detection3d.class_names}
+    thresholds: [0.5, 1.0, 2.0, 4.0]
+    min_num_points: 0
+    eval_class_range: ${t4dataset.detection3d.eval_class_range}
+    ranges: ${t4dataset.detection3d.metric_ranges}

--- a/autoware_ml/configs/datasets/t4dataset/lidar.yaml
+++ b/autoware_ml/configs/datasets/t4dataset/lidar.yaml
@@ -1,0 +1,12 @@
+# @package t4dataset.lidar
+
+defaults:
+  - /datasets/t4dataset/base
+  - _self_
+
+# Minimum LiDAR points required to keep a GT box during training, per radial band
+# (a point-density property of the sensor). Consumed by ObjectRangeMinPointsFilter
+# in every t4 detection/multi training pipeline via ${dataset.lidar.train_min_points_*}.
+# NOTE: this is training-only; the eval metric keeps min_num_points: 0 (counts every GT).
+train_min_points_near: 2   # within 0-60 m
+train_min_points_far: 1    # within 60-130 m

--- a/autoware_ml/configs/datasets/t4dataset/lidar.yaml
+++ b/autoware_ml/configs/datasets/t4dataset/lidar.yaml
@@ -4,5 +4,3 @@ defaults:
   - /datasets/t4dataset/base
   - _self_
 
-train_min_points_near: 2   # within 0-60 m
-train_min_points_far: 1    # within 60-130 m

--- a/autoware_ml/configs/datasets/t4dataset/lidar.yaml
+++ b/autoware_ml/configs/datasets/t4dataset/lidar.yaml
@@ -3,4 +3,3 @@
 defaults:
   - /datasets/t4dataset/base
   - _self_
-

--- a/autoware_ml/configs/datasets/t4dataset/lidar.yaml
+++ b/autoware_ml/configs/datasets/t4dataset/lidar.yaml
@@ -4,9 +4,5 @@ defaults:
   - /datasets/t4dataset/base
   - _self_
 
-# Minimum LiDAR points required to keep a GT box during training, per radial band
-# (a point-density property of the sensor). Consumed by ObjectRangeMinPointsFilter
-# in every t4 detection/multi training pipeline via ${dataset.lidar.train_min_points_*}.
-# NOTE: this is training-only; the eval metric keeps min_num_points: 0 (counts every GT).
 train_min_points_near: 2   # within 0-60 m
 train_min_points_far: 1    # within 60-130 m

--- a/autoware_ml/configs/datasets/t4dataset/segmentation3d.yaml
+++ b/autoware_ml/configs/datasets/t4dataset/segmentation3d.yaml
@@ -58,7 +58,7 @@ metrics:
         min_distance: 50.0
         max_distance: 90.0
       - _target_: autoware_ml.metrics.base.MetricRange
-        name: 90-121"
+        name: 90-121m
         min_distance: 90.0
         max_distance: 121.0
       - _target_: autoware_ml.metrics.base.MetricRange

--- a/autoware_ml/configs/datasets/t4dataset/segmentation3d.yaml
+++ b/autoware_ml/configs/datasets/t4dataset/segmentation3d.yaml
@@ -1,0 +1,67 @@
+# @package t4dataset.segmentation3d
+
+defaults:
+  - /datasets/t4dataset/base
+  - _self_
+
+ignore_index: -1
+
+class_mapping:
+  car: 0
+  emergency_vehicle: 0
+  forklift: 0
+  kart: 0
+  truck: 1
+  tractor_unit: 1
+  semi_trailer: 1
+  construction_vehicle: 1
+  bus: 2
+  motorcycle: 3
+  bicycle: 3
+  pedestrian: 4
+  personal_mobility: 4
+  stroller: 4
+  traffic_cone: 5
+  barrier: 6
+  debris: 7
+  pushable_pullable: 7
+  drivable_surface: 8
+  other_flat_surface: 9
+  sidewalk: 9
+  vegetation: 10
+  manmade: 11
+  vertical_thin: 12
+  other_stuff: 13
+  noise: 14
+  animal: ${ignore_index}
+  train: ${ignore_index}
+  ghost_point: ${ignore_index}
+  out_of_sync: ${ignore_index}
+  unpainted: ${ignore_index}
+num_classes: 15
+metrics:
+  - _target_: autoware_ml.metrics.segmentation3d.suite.Segmentation3DMetricSuite
+    components:
+      - { _target_: autoware_ml.metrics.segmentation3d.iou.IoU, stages: [val, test] }
+      - { _target_: autoware_ml.metrics.segmentation3d.accuracy.Accuracy, stages: [val, test] }
+      - { _target_: autoware_ml.metrics.segmentation3d.precision_recall_f1.PrecisionRecallF1, stages: [val, test] }
+    num_classes: ${t4dataset.segmentation3d.num_classes}
+    ignore_index: ${ignore_index}
+    class_names: ${seg_class_names:${t4dataset.segmentation3d.class_mapping}, ${t4dataset.segmentation3d.num_classes}}
+    ranges:
+      - _target_: autoware_ml.metrics.base.MetricRange
+        name: 0-50m
+        min_distance: 0.0
+        max_distance: 50.0
+      - _target_: autoware_ml.metrics.base.MetricRange
+        name: 50-90m
+        min_distance: 50.0
+        max_distance: 90.0
+      - _target_: autoware_ml.metrics.base.MetricRange
+        name: 90-121"
+        min_distance: 90.0
+        max_distance: 121.0
+      - _target_: autoware_ml.metrics.base.MetricRange
+        name: 0-121m
+        min_distance: 0.0
+        max_distance: 121.0

--- a/autoware_ml/configs/datasets/t4dataset/segmentation3d.yaml
+++ b/autoware_ml/configs/datasets/t4dataset/segmentation3d.yaml
@@ -33,11 +33,11 @@ class_mapping:
   vertical_thin: 12
   other_stuff: 13
   noise: 14
-  animal: ${ignore_index}
-  train: ${ignore_index}
-  ghost_point: ${ignore_index}
-  out_of_sync: ${ignore_index}
-  unpainted: ${ignore_index}
+  animal: ${t4dataset.segmentation3d.ignore_index}
+  train: ${t4dataset.segmentation3d.ignore_index}
+  ghost_point: ${t4dataset.segmentation3d.ignore_index}
+  out_of_sync: ${t4dataset.segmentation3d.ignore_index}
+  unpainted: ${t4dataset.segmentation3d.ignore_index}
 num_classes: 15
 metrics:
   - _target_: autoware_ml.metrics.segmentation3d.suite.Segmentation3DMetricSuite
@@ -46,7 +46,7 @@ metrics:
       - { _target_: autoware_ml.metrics.segmentation3d.accuracy.Accuracy, stages: [val, test] }
       - { _target_: autoware_ml.metrics.segmentation3d.precision_recall_f1.PrecisionRecallF1, stages: [val, test] }
     num_classes: ${t4dataset.segmentation3d.num_classes}
-    ignore_index: ${ignore_index}
+    ignore_index: ${t4dataset.segmentation3d.ignore_index}
     class_names: ${seg_class_names:${t4dataset.segmentation3d.class_mapping}, ${t4dataset.segmentation3d.num_classes}}
     ranges:
       - _target_: autoware_ml.metrics.base.MetricRange


### PR DESCRIPTION
## Summary

- New `datasets/{nuscenes,t4dataset}` with `lidar`/`camera`/`detection3d`/
  `segmentation3d` namespaces; tasks reference `${dataset.*}`.
- `data_root`/`camera_order`/class sets/min-points owned here (single source);
  t4 train min-points bands (`2`/`1`) live in `t4dataset/lidar.yaml`.

## Related Issues

<!-- Link related issues or feature requests -->

## Checklist

- [ ] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [ ] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

## Additional Notes

<!-- Anything else reviewers should know? -->

## Additional Log and Media

<!-- Any additional logs or information. -->
