### PR TITLE
fix(nuscenes): derive multiview prev_exists from scene tokens

### DIFF
--- a/autoware_ml/cli/cli.py
+++ b/autoware_ml/cli/cli.py
@@ -65,6 +65,15 @@ class OptionFirstTyperCommand(TyperCommand):
     """Suggest command options even when completion starts on an empty token."""
 
     def shell_complete(self, ctx: click.Context, incomplete: str) -> list[CompletionItem]:
+        """Return shell completions with options prioritized for empty tokens.
+
+        Args:
+            ctx: Active Click command context.
+            incomplete: Current incomplete shell token.
+
+        Returns:
+            Completion candidates for the current command line.
+        """
         results = super().shell_complete(ctx, incomplete)
         if incomplete:
             return results

--- a/autoware_ml/configs/tasks/detection3d/ptv3/voxel005_51m_nuscenes.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/voxel005_51m_nuscenes.yaml
@@ -20,7 +20,7 @@ datamodule:
   data_root: ${dataset.data_root}
   train_ann_file: nuscenes_infos_train.pkl
   val_ann_file: nuscenes_infos_val.pkl
-  test_ann_file: nuscenes_infos_test.pkl
+  test_ann_file: nuscenes_infos_val.pkl
   class_names: ${dataset.detection3d.class_names}
   name_mapping: ${dataset.detection3d.name_mapping}
   train_frame_sampling: null

--- a/autoware_ml/datamodule/common/multiview_detection3d.py
+++ b/autoware_ml/datamodule/common/multiview_detection3d.py
@@ -113,7 +113,18 @@ class MultiviewDetection3DDataset(Dataset):
         self.data_infos = load_detection_data_infos(data)
         if filter_frames_with_camera_order:
             self.data_infos = self._filter_frames_with_camera_order(self.data_infos)
+        self.prev_exists = self._build_prev_exists(self.data_infos)
         self.label_to_category = build_label_to_category(data.get("metainfo", {}))
+
+    @staticmethod
+    def _build_prev_exists(data_infos: list[dict[str, Any]]) -> np.ndarray:
+        """Build stream-continuity flags from adjacent scene tokens."""
+        prev_exists = np.zeros(len(data_infos), dtype=np.float32)
+        for index in range(1, len(data_infos)):
+            prev_exists[index] = np.float32(
+                data_infos[index - 1]["scene_token"] == data_infos[index]["scene_token"]
+            )
+        return prev_exists
 
     def _filter_frames_with_camera_order(
         self, data_infos: list[dict[str, Any]]
@@ -268,13 +279,11 @@ class MultiviewDetection3DDataset(Dataset):
                 sample.get("num_features", sample.get("lidar_points", {}).get("num_pts_feats", 5))
             ),
             "sweeps": self._resolve_sweeps(sample),
+            "scene_token": sample["scene_token"],
+            "prev_exists": self.prev_exists[index],
         }
         ego_pose = _build_ego_pose(sample)
         if ego_pose is not None:
             data_info["ego_pose"] = ego_pose
             data_info["ego_pose_inv"] = np.linalg.inv(ego_pose).astype(np.float32)
-        if "scene_token" in sample:
-            data_info["scene_token"] = sample["scene_token"]
-        if "prev_exists" in sample:
-            data_info["prev_exists"] = np.float32(sample["prev_exists"])
         return data_info

--- a/autoware_ml/tests/cli/test_cli.py
+++ b/autoware_ml/tests/cli/test_cli.py
@@ -163,7 +163,7 @@ class TestAdjustArgv:
     """Tests for adjust_argv."""
 
     def test_cli_syntax(self) -> None:
-        # Normal argv array — Hydra overrides with brackets pass through unchanged.
+        # Normal argv array - Hydra overrides with brackets pass through unchanged.
         argv = ["--config-name", SAMPLE_CONFIG_NAME, "trainer.devices=[0,1]", "model.lr=0.001"]
         assert adjust_argv(argv) == argv
 
@@ -556,8 +556,8 @@ class TestCliRuntime:
         self,
         tmp_path: Path,
     ) -> None:
-        config_name = "segmentation3d_detection3d/ptv3_segdet_transhead/voxel012"
-        experiment_name = "segmentation3d_detection3d_ptv3_segdet_transhead_voxel012"
+        config_name = "multi/ptv3/voxel012"
+        experiment_name = "multi_ptv3_voxel012"
         cfg = OmegaConf.create({"logger": {"tracking_uri": "sqlite:///mlruns/mlflow.db"}})
 
         with (

--- a/autoware_ml/tests/datamodule/test_multiview_detection3d.py
+++ b/autoware_ml/tests/datamodule/test_multiview_detection3d.py
@@ -77,5 +77,52 @@ def test_multiview_detection_dataset_applies_loader_pipeline(tmp_path: Path) -> 
     assert output["ego_pose"].shape == (4, 4)
     assert output["ego_pose_inv"].shape == (4, 4)
     assert output["scene_token"] == "scene-1"
+    assert output["prev_exists"] == np.float32(0.0)
     assert output["gt_boxes"].shape == (1, 9)
     assert output["gt_labels"].tolist() == [0]
+
+
+def test_multiview_detection_dataset_builds_prev_exists_from_scene_tokens(
+    tmp_path: Path,
+) -> None:
+    ann_file = tmp_path / "infos.pkl"
+    samples = [
+        {
+            "token": "sample-1",
+            "scene_token": "scene-1",
+            "prev_exists": True,
+            "lidar_points": {"lidar_path": "lidar-1.bin", "num_pts_feats": 5},
+            "images": {},
+            "instances": [],
+        },
+        {
+            "token": "sample-2",
+            "scene_token": "scene-1",
+            "prev_exists": False,
+            "lidar_points": {"lidar_path": "lidar-2.bin", "num_pts_feats": 5},
+            "images": {},
+            "instances": [],
+        },
+        {
+            "token": "sample-3",
+            "scene_token": "scene-2",
+            "prev_exists": True,
+            "lidar_points": {"lidar_path": "lidar-3.bin", "num_pts_feats": 5},
+            "images": {},
+            "instances": [],
+        },
+    ]
+    with open(ann_file, "wb") as file:
+        pickle.dump({"data_list": samples, "metainfo": {"classes": ["car"]}}, file)
+
+    dataset = _Dataset(
+        data_root=str(tmp_path),
+        ann_file=str(ann_file),
+        class_names=["car"],
+        camera_order=[],
+        filter_frames_with_camera_order=False,
+    )
+
+    assert dataset.get_data_info(0)["prev_exists"] == np.float32(0.0)
+    assert dataset.get_data_info(1)["prev_exists"] == np.float32(1.0)
+    assert dataset.get_data_info(2)["prev_exists"] == np.float32(0.0)

--- a/autoware_ml/tools/dataset/nuscenes/generator.py
+++ b/autoware_ml/tools/dataset/nuscenes/generator.py
@@ -27,10 +27,9 @@ from typing import Any
 
 import numpy as np
 import numpy.typing as npt
-from pyquaternion import Quaternion
-
 from nuscenes.nuscenes import NuScenes
 from nuscenes.utils import splits
+from pyquaternion import Quaternion
 
 from autoware_ml.tools.dataset.base import DatasetGenerator
 from autoware_ml.tools.dataset.nuscenes.tasks.registry import create_task
@@ -121,8 +120,7 @@ def _to_unified_record(
     """Reshape a working info dict into a unified v1.1 per-frame record.
 
     The unified record is consumed by every nuScenes task (detection3d,
-    segmentation3d, multiview/StreamPETR, and calibration_status), which expands
-    per-camera at load time.
+    segmentation3d, and calibration_status), which expand per-camera at load time.
 
     Args:
         info_dict: Working info dict with pose components, ``images`` and any

--- a/autoware_ml/tools/dataset/nuscenes/generator.py
+++ b/autoware_ml/tools/dataset/nuscenes/generator.py
@@ -153,7 +153,6 @@ def _to_unified_record(
         record["pts_semantic_mask_path"] = info_dict["pts_semantic_mask_path"]
     if "sweeps" in info_dict:
         record["sweeps"] = info_dict["sweeps"]
-    record["prev_exists"] = info_dict["prev_exists"]
     record["scene_token"] = info_dict["scene_token"]
     return record
 
@@ -503,11 +502,7 @@ class NuScenesDatasetGenerator(DatasetGenerator):
                 "lidar_path": lidar_path,
                 "num_features": 5,
                 "token": sample["token"],
-                # Temporal metadata for sequence models (e.g. StreamPETR): the scene
-                # id groups frames, and prev_exists is False at each scene's first
-                # keyframe so the temporal memory resets at sequence boundaries.
                 "scene_token": sample["scene_token"],
-                "prev_exists": sample["prev"] != "",
                 "images": {},
                 "lidar2ego_translation": cs_record["translation"],
                 "lidar2ego_rotation": cs_record["rotation"],

--- a/autoware_ml/transforms/boxes3d/merge.py
+++ b/autoware_ml/transforms/boxes3d/merge.py
@@ -170,15 +170,18 @@ class MergeObjects3D(BaseTransform):
         """Resolve an instance's canonical class name via ``name_mapping``.
 
         Args:
-            instance: Raw annotation dict expected to carry ``gt_nusc_name``.
+            instance: Raw annotation dict carrying ``gt_nusc_name``.
 
         Returns:
             The canonical class name (raw name when ``name_mapping`` is ``None``),
-            or ``None`` when the raw name is missing or maps to ``None``.
+            or ``None`` when the raw name maps to ``None``.
+
+        Raises:
+            KeyError: If ``gt_nusc_name`` is missing from the instance.
         """
-        raw_name = instance.get("gt_nusc_name")
-        if raw_name is None:
-            return None
+        if "gt_nusc_name" not in instance:
+            raise KeyError("MergeObjects3D requires every instance to contain 'gt_nusc_name'.")
+        raw_name = instance["gt_nusc_name"]
         raw_name = str(raw_name)
         if self.name_mapping is None:
             return raw_name


### PR DESCRIPTION
## Summary

- Use labeled nuScenes val annotations for PTv3 detection test config.
- Derive multiview prev_exists from adjacent scene_token values.
- Stop writing prev_exists into generated nuScenes annotation records.
- Update multiview datamodule tests for sequence reset behavior.
- Update CLI test config naming to current multi/ptv3/voxel012.

## Related Issues

<!-- Link related issues or feature requests -->

## Checklist

- [ ] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [ ] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

## Additional Notes

<!-- Anything else reviewers should know? -->

## Additional Log and Media

<!-- Any additional logs or information. -->
