### PR TITLE
fix(cli): resume checkpoint

### DIFF
--- a/autoware_ml/callbacks/early_stopping.py
+++ b/autoware_ml/callbacks/early_stopping.py
@@ -1,0 +1,62 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Early stopping with config-authoritative restore semantics."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any
+
+from lightning.pytorch.callbacks import EarlyStopping as LightningEarlyStopping
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigAuthoritativeStateMixin:
+    """Keep configured values when restoring callback state from a checkpoint.
+
+    Lightning restores a callback's full ``state_dict`` on resume, which
+    silently reverts configuration changes made between runs. This mixin
+    splits the state by a general rule: a state key that is also a
+    constructor parameter is configuration and the instantiated value wins;
+    every other key is runtime progress and is restored unchanged. Each
+    overridden value is logged.
+    """
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        """Restore runtime state while keeping configured values.
+
+        Args:
+            state_dict: Callback state loaded from a checkpoint.
+        """
+        config_keys = state_dict.keys() & inspect.signature(type(self).__init__).parameters.keys()
+        state = dict(state_dict)
+        for key in sorted(config_keys):
+            configured = getattr(self, key)
+            if state[key] != configured:
+                logger.warning(
+                    "%s.%s: checkpoint value %r overridden by configured value %r.",
+                    type(self).__name__,
+                    key,
+                    state[key],
+                    configured,
+                )
+            state[key] = configured
+        super().load_state_dict(state)
+
+
+class EarlyStopping(ConfigAuthoritativeStateMixin, LightningEarlyStopping):
+    """Early stopping whose configuration survives checkpoint resumes."""

--- a/autoware_ml/cli/cli.py
+++ b/autoware_ml/cli/cli.py
@@ -20,6 +20,7 @@ completion helpers used by the ``autoware-ml`` executable.
 
 import logging
 from importlib.metadata import version
+from pathlib import Path
 
 import click
 import typer
@@ -231,33 +232,49 @@ def train(
         typer.Option(
             "--resume-checkpoint",
             help="Full Lightning checkpoint path to resume training from "
-            "(restores model weights, optimizer state, and epoch). "
-            "Mutually exclusive with --weights.",
+            "(restores model weights, optimizer state, and epoch, and continues "
+            "the checkpoint's source MLflow run). Mutually exclusive with --weights.",
             autocompletion=complete_checkpoint_path,
         ),
     ] = None,
+    new_run: Annotated[
+        bool,
+        typer.Option(
+            "--new-run",
+            help="With --resume-checkpoint: continue the training state in a new "
+            "MLflow run instead of the checkpoint's source run.",
+        ),
+    ] = False,
 ) -> None:
     """Run model training through the Hydra-backed training entrypoint.
 
     Pass ``--weights`` to initialize model parameters from one or more pretrained
     checkpoints before training starts (e.g. transfer learning from a seg3d backbone
     into a det3d model). Pass ``--resume-checkpoint`` to resume an interrupted training
-    run from its full saved state. The two options are mutually exclusive.
+    run from its full saved state; it continues inside the checkpoint's source MLflow
+    run unless ``--new-run`` forks it. The two options are mutually exclusive.
 
     Args:
         ctx: Typer context containing additional Hydra overrides.
         config_name: Config name or config file path to train.
         weights: One or more checkpoint paths for pretrained weight initialization.
         resume_checkpoint: Full Lightning checkpoint path to resume training from.
+        new_run: Whether to fork the resumed training into a new MLflow run.
     """
     if weights and resume_checkpoint:
         raise typer.BadParameter("--weights and --resume-checkpoint are mutually exclusive.")
+    if new_run and not resume_checkpoint:
+        raise typer.BadParameter("--new-run requires --resume-checkpoint.")
 
     hydra_overrides: list[str] = []
     if weights:
         weights_list = "[" + ",".join(weights) + "]"
         hydra_overrides.append(f"+weights={weights_list}")
     if resume_checkpoint:
+        resume_path = Path(resume_checkpoint).expanduser().resolve()
+        if not resume_path.is_file():
+            raise typer.BadParameter(f"Resume checkpoint '{resume_checkpoint}' does not exist.")
+        resume_checkpoint = str(resume_path)
         hydra_overrides.append(f"+resume_checkpoint={resume_checkpoint}")
 
     run_lazy_script(
@@ -268,6 +285,8 @@ def train(
         stage="train",
         extra_args=ctx.args,
         hydra_overrides=hydra_overrides,
+        resume_checkpoint=resume_checkpoint,
+        new_run=new_run,
         config_prefix=TASK_CONFIG_PREFIX,
     )
 

--- a/autoware_ml/cli/runtime.py
+++ b/autoware_ml/cli/runtime.py
@@ -36,8 +36,11 @@ from autoware_ml.utils.cli.helpers import adjust_argv, resolve_config_reference,
 from autoware_ml.utils.mlflow_helpers import (
     AUTOWARE_ML_HYDRA_RUN_DIR_ENV,
     AUTOWARE_ML_RUN_ID_ENV,
+    RUN_METADATA_FILENAME,
     generate_experiment_name,
     generate_hydra_run_dir,
+    load_run_context,
+    load_run_metadata,
     prepare_run_context,
     resolve_deploy_lineage,
     resolve_lineage_context,
@@ -134,6 +137,45 @@ def temporary_environment(updates: dict[str, str | None]):
                 os.environ[key] = value
 
 
+def prepare_resume_environment(
+    tracking_uri: str,
+    config_name: str,
+    checkpoint_path: Path,
+) -> dict[str, str | None]:
+    """Reuse the resume checkpoint's source MLflow run for the launched command.
+
+    Args:
+        tracking_uri: MLflow tracking URI from the composed configuration.
+        config_name: User-facing config name for the current command.
+        checkpoint_path: Full Lightning checkpoint the training resumes from.
+
+    Returns:
+        Environment updates binding the run ID and Hydra directory of the
+        checkpoint's source run.
+
+    Raises:
+        ValueError: If the checkpoint has no run metadata or belongs to a
+            different config.
+    """
+    metadata = load_run_metadata(checkpoint_path)
+    if metadata is None:
+        raise ValueError(
+            f"No '{RUN_METADATA_FILENAME}' found in the parent directories of "
+            f"'{checkpoint_path}', so the source MLflow run cannot be reused. "
+            "Pass --new-run to resume into a fresh run."
+        )
+    if metadata["config_name"] != config_name:
+        raise ValueError(
+            f"Resume checkpoint belongs to config '{metadata['config_name']}', "
+            f"but '{config_name}' was launched."
+        )
+    run_context = load_run_context(tracking_uri, metadata["run_id"])
+    return {
+        AUTOWARE_ML_RUN_ID_ENV: run_context.run_id,
+        AUTOWARE_ML_HYDRA_RUN_DIR_ENV: str(run_context.hydra_dir),
+    }
+
+
 def prepare_runtime_environment(
     config_value: str,
     config_prefix: str,
@@ -142,6 +184,8 @@ def prepare_runtime_environment(
     hydra_overrides: Sequence[str] = (),
     checkpoint: str | None = None,
     checkpoints: Sequence[str] = (),
+    resume_checkpoint: str | None = None,
+    new_run: bool = False,
 ) -> dict[str, str | None]:
     """Prepare environment variables used by Hydra-backed runtime commands."""
     if checkpoint is not None and checkpoints:
@@ -167,6 +211,10 @@ def prepare_runtime_environment(
             cfg = compose(config_name=resolved_config_name, overrides=compose_overrides)
 
     if should_enable_logger(cfg):
+        if resume_checkpoint is not None and not new_run:
+            return prepare_resume_environment(
+                cfg.logger.tracking_uri, config_name, Path(resume_checkpoint)
+            )
         checkpoint_path = Path(checkpoint) if checkpoint is not None else None
         checkpoint_paths = [Path(path) for path in checkpoints]
         experiment_name = generate_experiment_name(config_name)
@@ -225,6 +273,8 @@ def run_hydra_entrypoint(
     hydra_overrides: Sequence[str] = (),
     checkpoint: str | None = None,
     checkpoints: Sequence[str] = (),
+    resume_checkpoint: str | None = None,
+    new_run: bool = False,
     config_prefix: str = TASK_CONFIG_PREFIX,
 ) -> None:
     """Execute one Hydra-backed runtime entrypoint through the CLI wrapper."""
@@ -238,6 +288,8 @@ def run_hydra_entrypoint(
             hydra_overrides=hydra_overrides,
             checkpoint=checkpoint,
             checkpoints=checkpoints,
+            resume_checkpoint=resume_checkpoint,
+            new_run=new_run,
         )
 
     sys.argv = resolve_hydra_entrypoint_argv(

--- a/autoware_ml/cli/runtime.py
+++ b/autoware_ml/cli/runtime.py
@@ -41,6 +41,7 @@ from autoware_ml.utils.mlflow_helpers import (
     generate_hydra_run_dir,
     load_run_context,
     load_run_metadata,
+    mark_run_running,
     prepare_run_context,
     resolve_deploy_lineage,
     resolve_lineage_context,
@@ -177,6 +178,7 @@ def prepare_resume_environment(
             f"but '{config_name}' was launched."
         )
     run_context = load_run_context(tracking_uri, metadata["run_id"])
+    mark_run_running(tracking_uri, run_context.run_id)
     return {
         AUTOWARE_ML_RUN_ID_ENV: run_context.run_id,
         AUTOWARE_ML_HYDRA_RUN_DIR_ENV: str(run_context.hydra_dir),

--- a/autoware_ml/cli/runtime.py
+++ b/autoware_ml/cli/runtime.py
@@ -164,6 +164,13 @@ def prepare_resume_environment(
             f"'{checkpoint_path}', so the source MLflow run cannot be reused. "
             "Pass --new-run to resume into a fresh run."
         )
+    missing_keys = [key for key in ("run_id", "config_name") if key not in metadata]
+    if missing_keys:
+        raise ValueError(
+            f"The '{RUN_METADATA_FILENAME}' next to '{checkpoint_path}' is missing "
+            f"{missing_keys}, so the source MLflow run cannot be reused. "
+            "Pass --new-run to resume into a fresh run."
+        )
     if metadata["config_name"] != config_name:
         raise ValueError(
             f"Resume checkpoint belongs to config '{metadata['config_name']}', "

--- a/autoware_ml/configs/defaults/modules/callbacks.yaml
+++ b/autoware_ml/configs/defaults/modules/callbacks.yaml
@@ -7,12 +7,18 @@ callbacks:
     dirpath: ${hydra:run.dir}/checkpoints
     filename: best
     save_top_k: 1
-    save_last: true
     mode: min
     verbose: true
 
+  model_checkpoint_last:
+    _target_: lightning.pytorch.callbacks.ModelCheckpoint
+    dirpath: ${hydra:run.dir}/checkpoints
+    filename: last
+    save_top_k: 1
+    enable_version_counter: false
+
   early_stopping:
-    _target_: lightning.pytorch.callbacks.EarlyStopping
+    _target_: autoware_ml.callbacks.early_stopping.EarlyStopping
     monitor: val/loss
     patience: 20
     mode: min

--- a/autoware_ml/scripts/test.py
+++ b/autoware_ml/scripts/test.py
@@ -144,7 +144,7 @@ def main(cfg: DictConfig):
         run_context.artifact_dir if run_context is not None else work_dir,
     )
 
-    log_hyperparameters(cfg, trainer_logger, trainer)
+    log_hyperparameters(cfg, trainer_logger)
 
     logger.info("Starting evaluation...")
     logger.info(f"Weights: {weight_paths}")

--- a/autoware_ml/scripts/train.py
+++ b/autoware_ml/scripts/train.py
@@ -100,7 +100,9 @@ def main(cfg: DictConfig):
     if weights_path is not None:
         apply_matching_weights(model, weights_path, map_location="cpu", logger=logger)
     if resume_checkpoint_path is not None:
-        progress = torch.load(resume_checkpoint_path, map_location="cpu", weights_only=False)
+        progress = torch.load(
+            resume_checkpoint_path, map_location="cpu", weights_only=False, mmap=True
+        )
         logger.info(
             "Resuming from '%s': checkpoint saved at epoch %d (global step %d), "
             "training continues at epoch %d.",
@@ -143,7 +145,7 @@ def main(cfg: DictConfig):
         run_context.artifact_dir if run_context is not None else work_dir,
     )
 
-    log_hyperparameters(cfg, trainer_logger, trainer)
+    log_hyperparameters(cfg, trainer_logger)
 
     # Start training
     logger.info("Starting training...")

--- a/autoware_ml/scripts/train.py
+++ b/autoware_ml/scripts/train.py
@@ -23,6 +23,7 @@ import os
 
 import hydra
 import lightning as L
+import torch
 from omegaconf import DictConfig
 
 from autoware_ml.utils.checkpoints import apply_matching_weights
@@ -98,6 +99,17 @@ def main(cfg: DictConfig):
         raise ValueError("'--resume-checkpoint' and '--weights' are mutually exclusive.")
     if weights_path is not None:
         apply_matching_weights(model, weights_path, map_location="cpu", logger=logger)
+    if resume_checkpoint_path is not None:
+        progress = torch.load(resume_checkpoint_path, map_location="cpu", weights_only=False)
+        logger.info(
+            "Resuming from '%s': checkpoint saved at epoch %d (global step %d), "
+            "training continues at epoch %d.",
+            resume_checkpoint_path,
+            progress["epoch"],
+            progress["global_step"],
+            progress["epoch"] + 1,
+        )
+        del progress
 
     logger.info("Instantiating callbacks...")
     callbacks = instantiate_callbacks(

--- a/autoware_ml/tests/cli/test_cli.py
+++ b/autoware_ml/tests/cli/test_cli.py
@@ -675,6 +675,7 @@ class TestCliRuntime:
                 "autoware_ml.cli.runtime.load_run_context",
                 return_value=SimpleNamespace(run_id="source-run", hydra_dir=tmp_path / "hydra"),
             ) as load_run_context_mock,
+            patch("autoware_ml.cli.runtime.mark_run_running") as mark_run_running_mock,
             patch("autoware_ml.cli.runtime.prepare_run_context") as prepare_run_context_mock,
         ):
             env_updates = cli_runtime.prepare_runtime_environment(
@@ -686,6 +687,7 @@ class TestCliRuntime:
 
         prepare_run_context_mock.assert_not_called()
         load_run_context_mock.assert_called_once()
+        mark_run_running_mock.assert_called_once_with("sqlite:///mlruns/mlflow.db", "source-run")
         assert env_updates["AUTOWARE_ML_RUN_ID"] == "source-run"
         assert env_updates["AUTOWARE_ML_HYDRA_RUN_DIR"] == str(tmp_path / "hydra")
 

--- a/autoware_ml/tests/cli/test_cli.py
+++ b/autoware_ml/tests/cli/test_cli.py
@@ -16,12 +16,13 @@
 
 import subprocess
 import sys
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from subprocess import CompletedProcess
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 from omegaconf import OmegaConf
 from typer.testing import CliRunner
 
@@ -209,6 +210,8 @@ class TestCliCommands:
             stage="train",
             extra_args=["+trainer.strategy=ddp", "trainer.devices=2"],
             hydra_overrides=[],
+            resume_checkpoint=None,
+            new_run=False,
             config_prefix=cli.TASK_CONFIG_PREFIX,
         )
 
@@ -228,14 +231,25 @@ class TestCliCommands:
             stage="train",
             extra_args=[],
             hydra_overrides=["+weights=[seg.ckpt]"],
+            resume_checkpoint=None,
+            new_run=False,
             config_prefix=cli.TASK_CONFIG_PREFIX,
         )
 
-    def test_train_runs_with_resume_checkpoint(self) -> None:
+    def test_train_runs_with_resume_checkpoint(self, tmp_path: Path) -> None:
+        checkpoint_path = tmp_path / "last.ckpt"
+        checkpoint_path.touch()
+
         with patch("autoware_ml.cli.cli.run_lazy_script") as run_lazy_script_mock:
             result = self.runner.invoke(
                 app,
-                ["train", "--config-name", SAMPLE_CONFIG_NAME, "--resume-checkpoint", "last.ckpt"],
+                [
+                    "train",
+                    "--config-name",
+                    SAMPLE_CONFIG_NAME,
+                    "--resume-checkpoint",
+                    str(checkpoint_path),
+                ],
             )
 
         assert result.exit_code == 0
@@ -246,9 +260,46 @@ class TestCliCommands:
             config_name=SAMPLE_CONFIG_NAME,
             stage="train",
             extra_args=[],
-            hydra_overrides=["+resume_checkpoint=last.ckpt"],
+            hydra_overrides=[f"+resume_checkpoint={checkpoint_path.resolve()}"],
+            resume_checkpoint=str(checkpoint_path.resolve()),
+            new_run=False,
             config_prefix=cli.TASK_CONFIG_PREFIX,
         )
+
+    def test_train_resolves_relative_resume_checkpoint(self, tmp_path: Path, monkeypatch) -> None:
+        checkpoint_path = tmp_path / "last.ckpt"
+        checkpoint_path.touch()
+        monkeypatch.chdir(tmp_path)
+
+        with patch("autoware_ml.cli.cli.run_lazy_script") as run_lazy_script_mock:
+            result = self.runner.invoke(
+                app,
+                ["train", "--config-name", SAMPLE_CONFIG_NAME, "--resume-checkpoint", "last.ckpt"],
+            )
+
+        assert result.exit_code == 0
+        resume_kwarg = run_lazy_script_mock.call_args.kwargs["resume_checkpoint"]
+        assert resume_kwarg == str(checkpoint_path.resolve())
+
+    def test_train_rejects_missing_resume_checkpoint(self) -> None:
+        result = self.runner.invoke(
+            app,
+            [
+                "train",
+                "--config-name",
+                SAMPLE_CONFIG_NAME,
+                "--resume-checkpoint",
+                "/nonexistent/last.ckpt",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_train_rejects_new_run_without_resume_checkpoint(self) -> None:
+        result = self.runner.invoke(
+            app,
+            ["train", "--config-name", SAMPLE_CONFIG_NAME, "--new-run"],
+        )
+        assert result.exit_code != 0
 
     def test_train_rejects_weights_and_resume_checkpoint_together(self) -> None:
         result = self.runner.invoke(
@@ -598,6 +649,101 @@ class TestCliRuntime:
             "seg-run,det-run"
         )
         assert env_updates["AUTOWARE_ML_RUN_ID"] == "deploy-run"
+
+    @contextmanager
+    def _patched_logger_config(self, config_name: str):
+        cfg = OmegaConf.create({"logger": {"tracking_uri": "sqlite:///mlruns/mlflow.db"}})
+        with (
+            patch(
+                "autoware_ml.cli.runtime.resolve_config_reference",
+                return_value=(None, f"tasks/{config_name}", []),
+            ),
+            patch("autoware_ml.cli.runtime.initialize_config_module", return_value=nullcontext()),
+            patch("autoware_ml.cli.runtime.compose", return_value=cfg),
+        ):
+            yield
+
+    def test_prepare_runtime_environment_reuses_source_run_for_resume(self, tmp_path: Path) -> None:
+        config_name = "multi/ptv3/voxel012"
+        with (
+            self._patched_logger_config(config_name),
+            patch(
+                "autoware_ml.cli.runtime.load_run_metadata",
+                return_value={"run_id": "source-run", "config_name": config_name},
+            ),
+            patch(
+                "autoware_ml.cli.runtime.load_run_context",
+                return_value=SimpleNamespace(run_id="source-run", hydra_dir=tmp_path / "hydra"),
+            ) as load_run_context_mock,
+            patch("autoware_ml.cli.runtime.prepare_run_context") as prepare_run_context_mock,
+        ):
+            env_updates = cli_runtime.prepare_runtime_environment(
+                config_name,
+                "tasks",
+                "train",
+                resume_checkpoint=str(tmp_path / "checkpoints" / "last.ckpt"),
+            )
+
+        prepare_run_context_mock.assert_not_called()
+        load_run_context_mock.assert_called_once()
+        assert env_updates["AUTOWARE_ML_RUN_ID"] == "source-run"
+        assert env_updates["AUTOWARE_ML_HYDRA_RUN_DIR"] == str(tmp_path / "hydra")
+
+    def test_prepare_runtime_environment_resume_new_run_creates_fresh_run(
+        self, tmp_path: Path
+    ) -> None:
+        config_name = "multi/ptv3/voxel012"
+        with (
+            self._patched_logger_config(config_name),
+            patch(
+                "autoware_ml.cli.runtime.prepare_run_context",
+                return_value=SimpleNamespace(run_id="fork-run", hydra_dir=tmp_path / "hydra"),
+            ) as prepare_run_context_mock,
+        ):
+            env_updates = cli_runtime.prepare_runtime_environment(
+                config_name,
+                "tasks",
+                "train",
+                resume_checkpoint=str(tmp_path / "last.ckpt"),
+                new_run=True,
+            )
+
+        prepare_run_context_mock.assert_called_once()
+        assert env_updates["AUTOWARE_ML_RUN_ID"] == "fork-run"
+
+    def test_prepare_runtime_environment_resume_without_metadata_fails(
+        self, tmp_path: Path
+    ) -> None:
+        config_name = "multi/ptv3/voxel012"
+        with (
+            self._patched_logger_config(config_name),
+            patch("autoware_ml.cli.runtime.load_run_metadata", return_value=None),
+            pytest.raises(ValueError, match="--new-run"),
+        ):
+            cli_runtime.prepare_runtime_environment(
+                config_name,
+                "tasks",
+                "train",
+                resume_checkpoint=str(tmp_path / "last.ckpt"),
+            )
+
+    def test_prepare_runtime_environment_resume_rejects_config_mismatch(
+        self, tmp_path: Path
+    ) -> None:
+        with (
+            self._patched_logger_config("multi/ptv3/voxel012"),
+            patch(
+                "autoware_ml.cli.runtime.load_run_metadata",
+                return_value={"run_id": "source-run", "config_name": "detection3d/other"},
+            ),
+            pytest.raises(ValueError, match="detection3d/other"),
+        ):
+            cli_runtime.prepare_runtime_environment(
+                "multi/ptv3/voxel012",
+                "tasks",
+                "train",
+                resume_checkpoint=str(tmp_path / "last.ckpt"),
+            )
 
 
 class TestResolveHydraArgv:

--- a/autoware_ml/tests/cli/test_cli.py
+++ b/autoware_ml/tests/cli/test_cli.py
@@ -727,6 +727,25 @@ class TestCliRuntime:
                 resume_checkpoint=str(tmp_path / "last.ckpt"),
             )
 
+    def test_prepare_runtime_environment_resume_rejects_incomplete_metadata(
+        self, tmp_path: Path
+    ) -> None:
+        config_name = "multi/ptv3/voxel012"
+        with (
+            self._patched_logger_config(config_name),
+            patch(
+                "autoware_ml.cli.runtime.load_run_metadata",
+                return_value={"experiment_name": "multi_ptv3_voxel012"},
+            ),
+            pytest.raises(ValueError, match="missing.*run_id.*config_name"),
+        ):
+            cli_runtime.prepare_runtime_environment(
+                config_name,
+                "tasks",
+                "train",
+                resume_checkpoint=str(tmp_path / "last.ckpt"),
+            )
+
     def test_prepare_runtime_environment_resume_rejects_config_mismatch(
         self, tmp_path: Path
     ) -> None:

--- a/autoware_ml/tests/framework/test_resume_support.py
+++ b/autoware_ml/tests/framework/test_resume_support.py
@@ -61,7 +61,7 @@ class TestResumedParamLogging:
         trainer_logger = self._logger_with_params({})
         cfg = OmegaConf.create({"trainer": {"max_epochs": 50}})
 
-        log_hyperparameters(cfg, trainer_logger, trainer=None)
+        log_hyperparameters(cfg, trainer_logger)
 
         trainer_logger.log_hyperparams.assert_called_once_with({"trainer": {"max_epochs": 50}})
 
@@ -78,7 +78,7 @@ class TestResumedParamLogging:
         )
 
         with caplog.at_level("WARNING"):
-            log_hyperparameters(cfg, trainer_logger, trainer=None)
+            log_hyperparameters(cfg, trainer_logger)
 
         trainer_logger.log_hyperparams.assert_called_once_with({"seed": 42})
         assert "callbacks/early_stopping/patience: 15 -> 40" in caplog.text
@@ -90,7 +90,7 @@ class TestResumedParamLogging:
         trainer_logger = self._logger_with_params({"trainer/max_epochs": "50"})
         cfg = OmegaConf.create({"trainer": {"max_epochs": 50}})
 
-        log_hyperparameters(cfg, trainer_logger, trainer=None)
+        log_hyperparameters(cfg, trainer_logger)
 
         trainer_logger.log_hyperparams.assert_called_once_with({})
         trainer_logger.experiment.set_tag.assert_not_called()

--- a/autoware_ml/tests/framework/test_resume_support.py
+++ b/autoware_ml/tests/framework/test_resume_support.py
@@ -1,0 +1,129 @@
+"""Tests for checkpoint-resume support: rolling last checkpoint, config-authoritative
+callback state, and append-only MLflow param logging."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import torch
+from lightning.pytorch.loggers import MLFlowLogger
+from omegaconf import OmegaConf
+
+from autoware_ml.callbacks.early_stopping import EarlyStopping
+from autoware_ml.utils.runtime import instantiate_callbacks, log_hyperparameters
+
+
+def _early_stopping_state(patience: int, wait_count: int) -> dict:
+    return {
+        "wait_count": wait_count,
+        "stopped_epoch": 0,
+        "best_score": torch.tensor(1.0),
+        "patience": patience,
+    }
+
+
+class TestConfigAuthoritativeEarlyStopping:
+    def test_configured_patience_wins_over_checkpoint(self, caplog) -> None:
+        callback = EarlyStopping(monitor="val/loss", patience=40, mode="min")
+
+        with caplog.at_level("WARNING"):
+            callback.load_state_dict(_early_stopping_state(patience=15, wait_count=7))
+
+        assert callback.patience == 40
+        assert "patience" in caplog.text
+
+    def test_runtime_state_is_restored(self) -> None:
+        callback = EarlyStopping(monitor="val/loss", patience=40, mode="min")
+
+        callback.load_state_dict(_early_stopping_state(patience=15, wait_count=7))
+
+        assert callback.wait_count == 7
+        assert float(callback.best_score) == 1.0
+
+    def test_identical_configuration_restores_silently(self, caplog) -> None:
+        callback = EarlyStopping(monitor="val/loss", patience=15, mode="min")
+
+        with caplog.at_level("WARNING"):
+            callback.load_state_dict(_early_stopping_state(patience=15, wait_count=3))
+
+        assert callback.patience == 15
+        assert caplog.text == ""
+
+
+class TestResumedParamLogging:
+    def _logger_with_params(self, params: dict[str, str]) -> MagicMock:
+        trainer_logger = MagicMock(spec=MLFlowLogger)
+        trainer_logger.run_id = "run-1"
+        trainer_logger.experiment.get_run.return_value.data.params = params
+        return trainer_logger
+
+    def test_fresh_run_logs_all_params(self) -> None:
+        trainer_logger = self._logger_with_params({})
+        cfg = OmegaConf.create({"trainer": {"max_epochs": 50}})
+
+        log_hyperparameters(cfg, trainer_logger, trainer=None)
+
+        trainer_logger.log_hyperparams.assert_called_once_with({"trainer": {"max_epochs": 50}})
+
+    def test_resumed_run_logs_only_new_keys_and_tags_drift(self, caplog) -> None:
+        trainer_logger = self._logger_with_params(
+            {"callbacks/early_stopping/patience": "15", "trainer/max_epochs": "50"}
+        )
+        cfg = OmegaConf.create(
+            {
+                "callbacks": {"early_stopping": {"patience": 40}},
+                "trainer": {"max_epochs": 50},
+                "seed": 42,
+            }
+        )
+
+        with caplog.at_level("WARNING"):
+            log_hyperparameters(cfg, trainer_logger, trainer=None)
+
+        trainer_logger.log_hyperparams.assert_called_once_with({"seed": 42})
+        assert "callbacks/early_stopping/patience: 15 -> 40" in caplog.text
+        trainer_logger.experiment.set_tag.assert_called_once_with(
+            "run-1", "param_drift", "callbacks/early_stopping/patience: 15 -> 40"
+        )
+
+    def test_resumed_run_without_changes_logs_nothing(self) -> None:
+        trainer_logger = self._logger_with_params({"trainer/max_epochs": "50"})
+        cfg = OmegaConf.create({"trainer": {"max_epochs": 50}})
+
+        log_hyperparameters(cfg, trainer_logger, trainer=None)
+
+        trainer_logger.log_hyperparams.assert_called_once_with({})
+        trainer_logger.experiment.set_tag.assert_not_called()
+
+
+class TestDefaultCheckpointCallbacks:
+    def test_rolling_last_checkpoint_saves_unconditionally(self, tmp_path) -> None:
+        cfg = OmegaConf.create(
+            {
+                "callbacks": {
+                    "model_checkpoint": {
+                        "_target_": "lightning.pytorch.callbacks.ModelCheckpoint",
+                        "monitor": "val/loss",
+                        "dirpath": str(tmp_path),
+                        "filename": "best",
+                        "save_top_k": 1,
+                        "mode": "min",
+                    },
+                    "model_checkpoint_last": {
+                        "_target_": "lightning.pytorch.callbacks.ModelCheckpoint",
+                        "dirpath": str(tmp_path),
+                        "filename": "last",
+                        "save_top_k": 1,
+                        "enable_version_counter": False,
+                    },
+                }
+            }
+        )
+
+        callbacks = instantiate_callbacks(cfg, checkpoint_dir=tmp_path / "checkpoints")
+
+        assert len(callbacks) == 2
+        best_callback, last_callback = callbacks
+        assert best_callback.monitor == "val/loss"
+        assert last_callback.monitor is None
+        assert all(cb.dirpath == str(tmp_path / "checkpoints") for cb in callbacks)

--- a/autoware_ml/tests/framework/test_resume_support.py
+++ b/autoware_ml/tests/framework/test_resume_support.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import torch
 from lightning.pytorch.loggers import MLFlowLogger
+from lightning.pytorch.utilities.rank_zero import rank_zero_only
 from omegaconf import OmegaConf
 
 from autoware_ml.callbacks.early_stopping import EarlyStopping
@@ -94,6 +95,18 @@ class TestResumedParamLogging:
 
         trainer_logger.log_hyperparams.assert_called_once_with({})
         trainer_logger.experiment.set_tag.assert_not_called()
+
+    def test_non_zero_rank_skips_param_reconciliation(self, monkeypatch) -> None:
+        # Off rank zero the MLflow experiment property returns a dummy whose
+        # get_run() yields None; touching it would crash every DDP launch.
+        monkeypatch.setattr(rank_zero_only, "rank", 1)
+        trainer_logger = self._logger_with_params({"trainer/max_epochs": "50"})
+        cfg = OmegaConf.create({"trainer": {"max_epochs": 50}})
+
+        log_hyperparameters(cfg, trainer_logger)
+
+        trainer_logger.experiment.get_run.assert_not_called()
+        trainer_logger.log_hyperparams.assert_called_once_with({"trainer": {"max_epochs": 50}})
 
 
 class TestDefaultCheckpointCallbacks:

--- a/autoware_ml/utils/mlflow_helpers.py
+++ b/autoware_ml/utils/mlflow_helpers.py
@@ -581,6 +581,17 @@ def load_run_context(tracking_uri: str, run_id: str) -> MlflowRunContext:
     )
 
 
+def mark_run_running(tracking_uri: str, run_id: str) -> None:
+    """Set a reused run's status back to RUNNING while it is resumed.
+
+    Args:
+        tracking_uri: MLflow tracking URI.
+        run_id: Run whose status is reset.
+    """
+    client = MlflowClient(tracking_uri=resolve_tracking_uri(tracking_uri))
+    client.update_run(run_id, status="RUNNING")
+
+
 def build_run_metadata(
     run_context: MlflowRunContext,
     config_name: str,

--- a/autoware_ml/utils/runtime.py
+++ b/autoware_ml/utils/runtime.py
@@ -202,13 +202,12 @@ def _drop_params_already_logged(trainer_logger: MLFlowLogger, params: dict) -> d
     return new_params
 
 
-def log_hyperparameters(cfg: DictConfig, trainer_logger: Logger | None, trainer: L.Trainer) -> None:
+def log_hyperparameters(cfg: DictConfig, trainer_logger: Logger | None) -> None:
     """Log resolved hyperparameters through the configured trainer logger.
 
     Args:
         cfg: Fully composed Hydra configuration.
         trainer_logger: Logger configured for the current trainer, if any.
-        trainer: Instantiated Lightning trainer.
     """
     if trainer_logger is None:
         return

--- a/autoware_ml/utils/runtime.py
+++ b/autoware_ml/utils/runtime.py
@@ -29,6 +29,7 @@ import torch
 from hydra.core.hydra_config import HydraConfig
 from lightning.fabric.utilities.logger import _convert_params, _flatten_dict
 from lightning.pytorch.loggers import Logger, MLFlowLogger
+from lightning.pytorch.utilities.rank_zero import rank_zero_only
 from omegaconf import DictConfig, OmegaConf, open_dict
 
 from autoware_ml.configs.paths import CONFIGS_ROOT
@@ -213,6 +214,8 @@ def log_hyperparameters(cfg: DictConfig, trainer_logger: Logger | None) -> None:
         return
 
     params = sanitize_mlflow_param_keys(OmegaConf.to_container(cfg, resolve=True))
-    if isinstance(trainer_logger, MLFlowLogger):
+    # Off rank zero the MLflow experiment is a dummy and log_hyperparams is a
+    # no-op, so the reconciliation must not (and cannot) run there.
+    if isinstance(trainer_logger, MLFlowLogger) and rank_zero_only.rank == 0:
         params = _drop_params_already_logged(trainer_logger, params)
     trainer_logger.log_hyperparams(params)

--- a/autoware_ml/utils/runtime.py
+++ b/autoware_ml/utils/runtime.py
@@ -27,7 +27,8 @@ import hydra
 import lightning as L
 import torch
 from hydra.core.hydra_config import HydraConfig
-from lightning.pytorch.loggers import Logger
+from lightning.fabric.utilities.logger import _convert_params, _flatten_dict
+from lightning.pytorch.loggers import Logger, MLFlowLogger
 from omegaconf import DictConfig, OmegaConf, open_dict
 
 from autoware_ml.configs.paths import CONFIGS_ROOT
@@ -158,6 +159,49 @@ def instantiate_trainer(
     )
 
 
+# Mirrors the value truncation MLFlowLogger.log_hyperparams applies before logging.
+_MLFLOW_PARAM_VALUE_LIMIT = 250
+_MLFLOW_TAG_VALUE_LIMIT = 5000
+_PARAM_DRIFT_TAG = "param_drift"
+
+
+def _drop_params_already_logged(trainer_logger: MLFlowLogger, params: dict) -> dict:
+    """Keep MLflow params append-only when attaching to an existing run.
+
+    MLflow params are immutable, so a resumed run may only log new keys.
+    Identical keys are skipped; changed keys keep their originally logged
+    value, and each one is warned about and recorded in the mutable
+    ``param_drift`` run tag. The values actually in effect are always the
+    composed configuration's.
+
+    Args:
+        trainer_logger: MLflow logger attached to the current run.
+        params: Sanitized configuration parameters about to be logged.
+
+    Returns:
+        Flattened parameters that are not yet logged on the run.
+    """
+    logged = trainer_logger.experiment.get_run(trainer_logger.run_id).data.params
+    if not logged:
+        return params
+
+    flattened = _flatten_dict(_convert_params(params))
+    new_params: dict[str, object] = {}
+    drifted: list[str] = []
+    for key, value in flattened.items():
+        if key not in logged:
+            new_params[key] = value
+        elif logged[key] != str(value)[:_MLFLOW_PARAM_VALUE_LIMIT]:
+            drifted.append(f"{key}: {logged[key]} -> {value}")
+    for entry in drifted:
+        logger.warning("Param drift against the run's logged params: %s", entry)
+    if drifted:
+        trainer_logger.experiment.set_tag(
+            trainer_logger.run_id, _PARAM_DRIFT_TAG, "; ".join(drifted)[:_MLFLOW_TAG_VALUE_LIMIT]
+        )
+    return new_params
+
+
 def log_hyperparameters(cfg: DictConfig, trainer_logger: Logger | None, trainer: L.Trainer) -> None:
     """Log resolved hyperparameters through the configured trainer logger.
 
@@ -169,5 +213,7 @@ def log_hyperparameters(cfg: DictConfig, trainer_logger: Logger | None, trainer:
     if trainer_logger is None:
         return
 
-    params = OmegaConf.to_container(cfg, resolve=True)
-    trainer_logger.log_hyperparams(sanitize_mlflow_param_keys(params))
+    params = sanitize_mlflow_param_keys(OmegaConf.to_container(cfg, resolve=True))
+    if isinstance(trainer_logger, MLFlowLogger):
+        params = _drop_params_already_logged(trainer_logger, params)
+    trainer_logger.log_hyperparams(params)

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -12,35 +12,38 @@ Bash completion is installed automatically by the Docker image build and by
 
 ## Commands
 
-| Command          | Purpose                                             |
-| ---------------- | --------------------------------------------------- |
-| `train`          | Train models using PyTorch Lightning                |
-| `test`           | Evaluate models from a checkpoint                   |
-| `deploy`         | Export models to ONNX and TensorRT                  |
-| `mlflow ui`      | Launch the MLflow tracking UI                       |
-| `mlflow export`  | Export one experiment into its own MLflow store     |
-| `session start`  | Start a managed background task                     |
-| `session attach` | View live terminal output from a background task    |
-| `session detach` | Disconnect raw tmux clients from a managed session  |
-| `session ls`     | List managed background tasks                       |
-| `session stop`   | Stop a managed background task                      |
-| `create-dataset` | Generate dataset info files                         |
+| Command          | Purpose                                            |
+| ---------------- | -------------------------------------------------- |
+| `train`          | Train models using PyTorch Lightning               |
+| `test`           | Evaluate models from a checkpoint                  |
+| `deploy`         | Export models to ONNX and TensorRT                 |
+| `mlflow ui`      | Launch the MLflow tracking UI                      |
+| `mlflow export`  | Export one experiment into its own MLflow store    |
+| `session start`  | Start a managed background task                    |
+| `session attach` | View live terminal output from a background task   |
+| `session detach` | Disconnect raw tmux clients from a managed session |
+| `session ls`     | List managed background tasks                      |
+| `session stop`   | Stop a managed background task                     |
+| `create-dataset` | Generate dataset info files                        |
 
 ## train
 
 Train a model using the specified Hydra configuration.
 
 ```bash
-autoware-ml train --config-name <config_path> [--weights <path> ...] [--resume-checkpoint <path>] [hydra_overrides...]
+autoware-ml train --config-name <config_path> [--weights <path> ...] [--resume-checkpoint <path>] [--new-run] [hydra_overrides...]
 ```
 
 **Arguments:**
 
 - `--config-name`: Path to config
 - `--weights`: One or more `.ckpt` paths for pretrained weight initialization (repeatable; later checkpoints overwrite earlier ones on overlapping keys). Use this for transfer learning, e.g. initializing a det3d backbone from a seg3d checkpoint. Mutually exclusive with `--resume-checkpoint`.
-- `--resume-checkpoint`: Full Lightning checkpoint path to resume an interrupted training run from (restores model weights, optimizer state, and epoch). Mutually exclusive with `--weights`.
+- `--resume-checkpoint`: Full Lightning checkpoint path to resume an interrupted training run from (restores model weights, optimizer state, and epoch). Training continues inside the checkpoint's source MLflow run: same run ID, metric curves, and checkpoint directory. Mutually exclusive with `--weights`.
+- `--new-run`: With `--resume-checkpoint`, fork the training state into a new MLflow run instead of continuing the source run.
 
 All remaining arguments are passed to Hydra as overrides. See [Configuration](configuration.md) for details.
+
+Resuming with a modified configuration is supported: the current config is authoritative for training, callback settings such as early-stopping patience take their configured values, and MLflow keeps the originally logged params (they are immutable) - every changed key is reported in a startup warning and in the run's `param_drift` tag, and the config artifact records the exact resumed configuration.
 
 **Examples:**
 


### PR DESCRIPTION
## Summary

- Fixed `last.ckpt` freezing at the best epoch: Lightning's `save_last` only mirrors monitor-driven saves, so runs whose `val/loss` peaked early had no usable resume point; a dedicated monitor-less `ModelCheckpoint` now saves it every epoch.
- `--resume-checkpoint` continues the checkpoint's source MLflow run (same run ID, checkpoint dir, and metric curves) via the adjacent `run_metadata.json`; fails at launch on missing metadata or config mismatch.
- Added `--new-run` to explicitly fork a resumed training into a fresh MLflow run.
- Resuming with a modified config now works: params stay append-only (MLflow immutability), changed keys are warned per key and recorded in a `param_drift` run tag.
- New `ConfigAuthoritativeStateMixin` for callbacks: on restore, state keys that are also constructor parameters take the configured value (e.g. early-stopping patience), runtime state like `wait_count` is restored unchanged; no field names hardcoded.
- `train.py` logs the resume checkpoint's epoch/step before fitting, so a stale checkpoint is visible immediately.
- Resume paths are resolved to absolute and validated in the CLI.

TODO: logger abstraction (remove MLFlow hard dependency).

## Related Issues

<!-- Link related issues or feature requests -->

## Checklist

- [ ] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [ ] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

## Additional Notes

<!-- Anything else reviewers should know? -->

## Additional Log and Media

<!-- Any additional logs or information. -->
