### PR TITLE
feat(framework): make experiments reproducible via seeding and deterministic execution

### DIFF
--- a/autoware_ml/configs/defaults/modules/trainer.yaml
+++ b/autoware_ml/configs/defaults/modules/trainer.yaml
@@ -1,5 +1,7 @@
 # @package _global_
 
+seed: 3407
+
 trainer:
   _target_: lightning.Trainer
   max_epochs: 10
@@ -7,6 +9,7 @@ trainer:
   strategy: auto
   devices: auto
   precision: 32-true
+  deterministic: warn
   log_every_n_steps: 50
   val_check_interval: 1.0
   check_val_every_n_epoch: 1

--- a/autoware_ml/datamodule/pipeline_context.py
+++ b/autoware_ml/datamodule/pipeline_context.py
@@ -13,6 +13,18 @@ from autoware_ml.transforms.base import TransformsCompose
 logger = logging.getLogger(__name__)
 
 
+def _seeded_rng() -> np.random.Generator:
+    """Derive a generator from the globally seeded NumPy state.
+
+    ``seed_everything(workers=True)`` seeds the global NumPy RNG per dataloader
+    worker, so deriving from it keeps secondary-sample draws reproducible.
+
+    Returns:
+        Generator seeded from the global NumPy RNG.
+    """
+    return np.random.default_rng(np.random.randint(2**32))
+
+
 @dataclass
 class PipelineContext:
     """Provide dataset access for context-aware transforms.
@@ -24,7 +36,7 @@ class PipelineContext:
 
     dataset: Any
     index: int
-    rng: np.random.Generator = field(default_factory=np.random.default_rng)
+    rng: np.random.Generator = field(default_factory=_seeded_rng)
 
     def get_data_info(self, index: int) -> dict[str, Any]:
         """Load raw metadata for the requested dataset index.

--- a/autoware_ml/models/segmentation3d/encoders/ptv3.py
+++ b/autoware_ml/models/segmentation3d/encoders/ptv3.py
@@ -518,6 +518,7 @@ class SerializedAttention(PointModule):
                 max_seqlen=patch_size,
                 dropout_p=self.attn_drop_p if self.training else 0.0,
                 softmax_scale=self.scale,
+                deterministic=True,
             ).reshape(-1, channel_count)
             feat = feat.to(qkv.dtype)
         feat = feat[inverse]

--- a/autoware_ml/tests/models/test_ptv3_encoder.py
+++ b/autoware_ml/tests/models/test_ptv3_encoder.py
@@ -60,7 +60,8 @@ def test_serialized_attention_uses_flash_module_when_enabled() -> None:
         cu_seqlens,
         max_seqlen,
         dropout_p,
-        softmax_scale: (qkv[:, 2])
+        softmax_scale,
+        deterministic=False: (qkv[:, 2])
     )
     point = Point(
         {
@@ -103,7 +104,8 @@ def test_build_export_module_disables_flash_attention_without_mutating_live_enco
         cu_seqlens,
         max_seqlen,
         dropout_p,
-        softmax_scale: (qkv[:, 2])
+        softmax_scale,
+        deterministic=False: (qkv[:, 2])
     )
     with patch(
         "autoware_ml.models.segmentation3d.encoders.ptv3.load_flash_attn_module",

--- a/autoware_ml/tests/transforms/test_segmentation3d.py
+++ b/autoware_ml/tests/transforms/test_segmentation3d.py
@@ -80,7 +80,7 @@ def test_frustum_mix_combines_points_from_source_and_mix_sample() -> None:
     dataset = _MixDataset(mix_sample)
     output = FrustumMix(height=8, width=16, fov_up=10.0, fov_down=-30.0, num_areas=[2], p=1.0)(
         sample,
-        context=PipelineContext(dataset=dataset, index=0),
+        context=PipelineContext(dataset=dataset, index=0, rng=np.random.default_rng(0)),
     )
 
     assert output["points"].shape[1] == 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,11 @@ extra-index-urls = ["https://download.pytorch.org/whl/cu128", "https://pypi.nvid
 # so `first-index` would stop before considering the NVIDIA index.
 index-strategy = "unsafe-best-match"
 
+[tool.pixi.activation.env]
+# cuBLAS is only deterministic with a fixed workspace size; the trainer's
+# `deterministic` mode (torch.use_deterministic_algorithms) depends on it.
+CUBLAS_WORKSPACE_CONFIG = ":4096:8"
+
 [tool.pixi.dependencies]
 # Pixi keeps a small conda-forge base for Python and installer tooling. The
 # runtime stack comes from [project.dependencies] via PyPI.


### PR DESCRIPTION
## Summary

- Seed all random number generators (Python, NumPy, torch, CUDA) through `seed_everything(seed, workers=True)` with a global `seed` defined in the trainer defaults, so every run — including dataloader workers — starts from a reproducible state.
- Enable `deterministic: warn` on the trainer: torch ops take deterministic kernel paths, and any future op without a deterministic implementation announces itself in the logs instead of silently diverging.
- Derive `PipelineContext`'s RNG from the globally seeded NumPy state instead of an unseeded generator, making secondary-sample draws in transforms (e.g. mix-style augmentations) reproducible per worker.
- Export `CUBLAS_WORKSPACE_CONFIG=:4096:8` via the pixi activation environment, so deterministic cuBLAS is guaranteed for both container and local pixi installations from a single source (requires an image rebuild to reach baked containers).
- Hardcode `deterministic=True` in PTv3's flash-attention call: the default backward accumulates `dq` with atomic adds, producing non-reproducible gradients; the deterministic variant costs ≤12% on the attention op (low single-digit % per training step) and does not affect inference or export.
- Pin the RNG explicitly in the `FrustumMix` test to keep it independent of global seeding state.

### Validation

- Dataloader batches, model initialization, and the full first device-side batch are bit-identical across independent processes (SHA-256 verified); a different seed produces different digests.
- Two 10-step PTv3 training runs reproduced bit-exactly (identical per-step losses and final-weights hash) across separate processes, modulo the spconv limitation below.

### Known limitation

- spconv (2.3.6) selects kernel configurations by benchmarking them at first call; this once-per-process timing-based pick chooses between a small set of near-tied kernels, each individually deterministic (~1e-3 relative loss spread, no metric impact). It affects forward passes too, so bit-exact equality across runs is not guaranteed until spconv offers a deterministic selection policy — there is no supported knob in 2.3.6.

## Related Issues

<!-- Link related issues or feature requests -->

## Checklist

- [ ] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [ ] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

## Additional Notes

<!-- Anything else reviewers should know? -->

## Additional Log and Media

<!-- Any additional logs or information. -->
