### PR TITLE
fix(datamodule): store annotations in a fork-shared serialized buffer to stop DataLoader OOM

### DIFF
--- a/autoware_ml/datamodule/common/multiview_detection3d.py
+++ b/autoware_ml/datamodule/common/multiview_detection3d.py
@@ -33,6 +33,7 @@ from autoware_ml.datamodule.common.detection3d import (
     build_label_to_category,
     load_detection_data_infos,
 )
+from autoware_ml.datamodule.common.serialization import SerializedSampleList
 
 logger = logging.getLogger(__name__)
 
@@ -110,11 +111,14 @@ class MultiviewDetection3DDataset(Dataset):
         self.require_image_files = require_image_files
         with open(ann_file, "rb") as file:
             data = pickle.load(file)
-        self.data_infos = load_detection_data_infos(data)
+        data_infos = load_detection_data_infos(data)
         if filter_frames_with_camera_order:
-            self.data_infos = self._filter_frames_with_camera_order(self.data_infos)
-        self.prev_exists = self._build_prev_exists(self.data_infos)
+            data_infos = self._filter_frames_with_camera_order(data_infos)
+        self.prev_exists = self._build_prev_exists(data_infos)
         self.label_to_category = build_label_to_category(data.get("metainfo", {}))
+        # Serialize last: the full passes above must run on the live list.
+        self._scene_index_groups = self._build_scene_index_groups(data_infos)
+        self.data_infos = SerializedSampleList(data_infos)
 
     @staticmethod
     def _build_prev_exists(data_infos: list[dict[str, Any]]) -> np.ndarray:
@@ -170,6 +174,23 @@ class MultiviewDetection3DDataset(Dataset):
             Number of samples available in the annotation file.
         """
         return len(self.data_infos)
+
+    @staticmethod
+    def _build_scene_index_groups(data_infos: list[dict[str, Any]]) -> list[list[int]]:
+        """Group dataset indices by scene, preserving frame order."""
+        groups: dict[str, list[int]] = {}
+        for index, sample in enumerate(data_infos):
+            groups.setdefault(sample["scene_token"], []).append(index)
+        return list(groups.values())
+
+    def scene_index_groups(self) -> list[list[int]]:
+        """Group dataset indices by scene, preserving frame order.
+
+        Returns:
+            One list of scene-contiguous dataset indices per scene. A fresh
+            copy is returned so callers may mutate it freely.
+        """
+        return [list(group) for group in self._scene_index_groups]
 
     def _resolve_path(self, relative_path: str) -> str:
         """Resolve a path relative to the dataset root.

--- a/autoware_ml/datamodule/common/serialization.py
+++ b/autoware_ml/datamodule/common/serialization.py
@@ -1,0 +1,67 @@
+"""Fork-shareable storage for large annotation sample lists.
+
+Datasets that hold annotations as a plain ``list[dict]`` inflate multi-worker
+training memory: every DataLoader worker forked from the main process touches
+the objects' reference counts while reading them, which dirties the
+copy-on-write pages and gradually privatizes the whole annotation list in every
+worker. Storing the samples as one contiguous pickle buffer removes the
+per-object refcounts, so all workers keep sharing the parent's pages.
+"""
+
+from __future__ import annotations
+
+import pickle
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+
+
+class SerializedSampleList(Sequence):
+    """Immutable sample list stored as one pickle buffer plus offsets.
+
+    Drop-in replacement for a ``list[dict]`` that only needs ``len()`` and
+    integer indexing. ``__getitem__`` deserializes a single record on demand
+    and returns a fresh object, so mutations of returned samples do not
+    persist. Build it as the last step of dataset ``__init__``, after any
+    full-pass computations over the live list.
+    """
+
+    def __init__(self, samples: Sequence[dict[str, Any]]) -> None:
+        """Serialize *samples* into one contiguous buffer.
+
+        Args:
+            samples: Annotation records to store.
+        """
+        offsets = np.zeros(len(samples) + 1, dtype=np.int64)
+        parts: list[bytes] = []
+        for index, sample in enumerate(samples):
+            part = pickle.dumps(sample, protocol=pickle.HIGHEST_PROTOCOL)
+            parts.append(part)
+            offsets[index + 1] = offsets[index] + len(part)
+        self._offsets = offsets
+        self._buffer = b"".join(parts)
+
+    def __len__(self) -> int:
+        """Return the number of stored samples."""
+        return len(self._offsets) - 1
+
+    def __getitem__(self, index: int) -> dict[str, Any]:
+        """Deserialize and return the sample at *index*.
+
+        Args:
+            index: Integer sample index; negative indices are supported.
+
+        Returns:
+            A fresh deserialized copy of the stored sample.
+        """
+        if isinstance(index, slice):
+            raise TypeError("SerializedSampleList does not support slicing.")
+        length = len(self)
+        if index < 0:
+            index += length
+        if not 0 <= index < length:
+            raise IndexError(f"Index {index} out of range for {length} samples.")
+        start = int(self._offsets[index])
+        end = int(self._offsets[index + 1])
+        return pickle.loads(memoryview(self._buffer)[start:end])

--- a/autoware_ml/datamodule/nuscenes/detection3d.py
+++ b/autoware_ml/datamodule/nuscenes/detection3d.py
@@ -30,6 +30,7 @@ from autoware_ml.datamodule.common.detection3d import (
     build_label_to_category,
     load_detection_data_infos,
 )
+from autoware_ml.datamodule.common.serialization import SerializedSampleList
 from autoware_ml.datamodule.nuscenes.common import resolve_lidar_path
 from autoware_ml.transforms.base import TransformsCompose
 
@@ -64,8 +65,8 @@ class NuscenesDetection3DDataset(Dataset):
         self.name_mapping = dict(name_mapping) if name_mapping is not None else None
         with open(ann_file, "rb") as file:
             data = pickle.load(file)
-        self.data_infos = load_detection_data_infos(data)
         self.label_to_category = build_label_to_category(data.get("metainfo", {}))
+        self.data_infos = SerializedSampleList(load_detection_data_infos(data))
 
     def __len__(self) -> int:
         """Return the number of annotated samples.

--- a/autoware_ml/datamodule/nuscenes/segdet.py
+++ b/autoware_ml/datamodule/nuscenes/segdet.py
@@ -30,6 +30,7 @@ from autoware_ml.datamodule.common.detection3d import (
     load_detection_data_infos,
     normalize_detection_sample,
 )
+from autoware_ml.datamodule.common.serialization import SerializedSampleList
 from autoware_ml.datamodule.nuscenes.common import resolve_lidar_path
 from autoware_ml.datamodule.t4dataset.detection3d import (
     FrameSamplingConfig,
@@ -89,7 +90,7 @@ class NuscenesSegmentationDetection3DDataset(Dataset):
 
         raw_infos = load_detection_data_infos(data)
 
-        self.data_infos: list[dict[str, Any]] = []
+        data_infos: list[dict[str, Any]] = []
         for raw_sample in raw_infos:
             if "pts_semantic_mask_path" not in raw_sample:
                 raise ValueError(
@@ -100,14 +101,16 @@ class NuscenesSegmentationDetection3DDataset(Dataset):
             sample = normalize_detection_sample(raw_sample)
             sample["label_to_category"] = self.label_to_category
             sample["pts_semantic_mask_path"] = raw_sample["pts_semantic_mask_path"]
-            self.data_infos.append(sample)
+            data_infos.append(sample)
 
         self.frame_weights = compute_frame_sampling_weights(
-            self.data_infos,
+            data_infos,
             self.class_names,
             self.name_mapping or {},
             self.frame_sampling,
         )
+        # Serialize last: frame_weights above must run on the live list.
+        self.data_infos = SerializedSampleList(data_infos)
 
     def __len__(self) -> int:
         """Return the number of NuScenes segdet samples."""

--- a/autoware_ml/datamodule/nuscenes/segmentation3d.py
+++ b/autoware_ml/datamodule/nuscenes/segmentation3d.py
@@ -25,6 +25,7 @@ import pickle
 from typing import Any
 
 from autoware_ml.datamodule.base import DataModule, Dataset
+from autoware_ml.datamodule.common.serialization import SerializedSampleList
 from autoware_ml.datamodule.nuscenes.common import resolve_lidar_path
 from autoware_ml.transforms.base import TransformsCompose
 
@@ -63,7 +64,9 @@ class NuscenesSegmentation3DDataset(Dataset):
         with open(ann_file, "rb") as file:
             data = pickle.load(file)
 
-        self.data_infos = data["data_list"] if "data_list" in data else data["infos"]
+        self.data_infos = SerializedSampleList(
+            data["data_list"] if "data_list" in data else data["infos"]
+        )
 
     def __len__(self) -> int:
         """Return the number of annotated samples.

--- a/autoware_ml/datamodule/t4dataset/calibration_status.py
+++ b/autoware_ml/datamodule/t4dataset/calibration_status.py
@@ -21,6 +21,7 @@ from typing import Any
 import numpy as np
 
 from autoware_ml.datamodule.base import DataModule, Dataset
+from autoware_ml.datamodule.common.serialization import SerializedSampleList
 from autoware_ml.transforms.base import TransformsCompose
 from autoware_ml.utils.calibration import CalibrationData, CalibrationStatus
 
@@ -50,7 +51,7 @@ class T4CalibrationStatusDataset(Dataset):
             raise ValueError(
                 f"Unknown info file format. Expected 'data_list' key, got: {list(raw.keys())}"
             )
-        self.data_infos = raw["data_list"]
+        self.data_infos = SerializedSampleList(raw["data_list"])
 
     def __len__(self) -> int:
         """Get dataset length.

--- a/autoware_ml/datamodule/t4dataset/detection3d.py
+++ b/autoware_ml/datamodule/t4dataset/detection3d.py
@@ -36,6 +36,7 @@ from autoware_ml.datamodule.common.detection3d import (
     resolve_data_path,
     resolve_sweep_paths,
 )
+from autoware_ml.datamodule.common.serialization import SerializedSampleList
 from autoware_ml.transforms.base import TransformsCompose
 from autoware_ml.transforms.boxes3d.annotations import (
     box_is_physical,
@@ -227,15 +228,17 @@ class T4Detection3DDataset(Dataset):
 
         with open(ann_file, "rb") as file:
             data = pickle.load(file)
-        self.data_infos = load_detection_data_infos(data)
+        data_infos = load_detection_data_infos(data)
         self.frame_weights = compute_frame_sampling_weights(
-            self.data_infos,
+            data_infos,
             self.class_names,
             self.name_mapping,
             self.frame_sampling,
             filter_attributes=filter_attributes,
             use_valid_flag=use_valid_flag,
         )
+        # Serialize last: frame_weights above must run on the live list.
+        self.data_infos = SerializedSampleList(data_infos)
 
     def __len__(self) -> int:
         """Return the number of annotated samples.

--- a/autoware_ml/datamodule/t4dataset/segdet.py
+++ b/autoware_ml/datamodule/t4dataset/segdet.py
@@ -37,6 +37,7 @@ from autoware_ml.datamodule.common.detection3d import (
     resolve_data_path,
     resolve_sweep_paths,
 )
+from autoware_ml.datamodule.common.serialization import SerializedSampleList
 from autoware_ml.datamodule.common.sources import AnnotationSource, coerce_annotation_sources
 from autoware_ml.datamodule.t4dataset.detection3d import (
     FrameSamplingConfig,
@@ -70,18 +71,20 @@ class T4SegmentationDetection3DDataset(Dataset):
         self.use_valid_flag = use_valid_flag
         self.frame_sampling = frame_sampling
 
-        self.data_infos: list[dict[str, Any]] = []
+        data_infos: list[dict[str, Any]] = []
         for source in ann_sources:
-            self.data_infos.extend(self._load_source(source))
+            data_infos.extend(self._load_source(source))
 
         self.frame_weights = compute_frame_sampling_weights(
-            self.data_infos,
+            data_infos,
             self.class_names,
             self.name_mapping,
             self.frame_sampling,
             self.filter_attributes,
             self.use_valid_flag,
         )
+        # Serialize last: frame_weights above must run on the live list.
+        self.data_infos = SerializedSampleList(data_infos)
 
     def _load_source(self, source: AnnotationSource) -> list[dict[str, Any]]:
         """Load one annotation source and apply its supervision declaration."""

--- a/autoware_ml/datamodule/t4dataset/segmentation3d.py
+++ b/autoware_ml/datamodule/t4dataset/segmentation3d.py
@@ -26,6 +26,7 @@ import pickle
 from typing import Any
 
 from autoware_ml.datamodule.base import DataModule, Dataset
+from autoware_ml.datamodule.common.serialization import SerializedSampleList
 from autoware_ml.transforms.base import TransformsCompose
 
 logger = logging.getLogger(__name__)
@@ -66,7 +67,9 @@ class T4Segmentation3DDataset(Dataset):
         with open(ann_file, "rb") as file:
             data = pickle.load(file)
 
-        self.data_infos = data["data_list"] if "data_list" in data else data["infos"]
+        self.data_infos = SerializedSampleList(
+            data["data_list"] if "data_list" in data else data["infos"]
+        )
 
     def __len__(self) -> int:
         """Return the number of segmentation samples.

--- a/autoware_ml/tests/datamodule/test_serialization.py
+++ b/autoware_ml/tests/datamodule/test_serialization.py
@@ -1,0 +1,99 @@
+import multiprocessing
+import pickle
+
+import numpy as np
+import pytest
+
+from autoware_ml.datamodule.common.serialization import SerializedSampleList
+
+
+def _make_samples(count: int = 5) -> list[dict]:
+    return [
+        {
+            "token": f"sample_{index}",
+            "scene_token": f"scene_{index // 2}",
+            "timestamp": 1700000000.0 + index,
+            "instances": [{"bbox_label_3d": index, "bbox_3d": [0.1 * index] * 7}],
+            "lidar_points": {"lidar_path": f"scene/{index}.pcd.bin", "num_pts_feats": 5},
+            "array": np.arange(4, dtype=np.float32) + index,
+        }
+        for index in range(count)
+    ]
+
+
+class TestSerializedSampleList:
+    def test_roundtrip_matches_original(self) -> None:
+        samples = _make_samples()
+        serialized = SerializedSampleList(samples)
+
+        assert len(serialized) == len(samples)
+        for index, original in enumerate(samples):
+            restored = serialized[index]
+            assert restored["token"] == original["token"]
+            assert restored["instances"] == original["instances"]
+            assert restored["lidar_points"] == original["lidar_points"]
+            np.testing.assert_array_equal(restored["array"], original["array"])
+
+    def test_negative_index_and_bounds(self) -> None:
+        samples = _make_samples(3)
+        serialized = SerializedSampleList(samples)
+
+        assert serialized[-1]["token"] == samples[-1]["token"]
+        with pytest.raises(IndexError):
+            serialized[3]
+        with pytest.raises(IndexError):
+            serialized[-4]
+
+    def test_iteration_visits_all_samples(self) -> None:
+        samples = _make_samples(4)
+        serialized = SerializedSampleList(samples)
+
+        tokens = [sample["token"] for sample in serialized]
+
+        assert tokens == [sample["token"] for sample in samples]
+
+    def test_slicing_is_rejected(self) -> None:
+        serialized = SerializedSampleList(_make_samples(2))
+
+        with pytest.raises(TypeError):
+            serialized[0:2]
+
+    def test_returned_samples_are_independent_copies(self) -> None:
+        serialized = SerializedSampleList(_make_samples(1))
+
+        first = serialized[0]
+        first["token"] = "mutated"
+
+        assert serialized[0]["token"] == "sample_0"
+
+    def test_empty_list(self) -> None:
+        serialized = SerializedSampleList([])
+
+        assert len(serialized) == 0
+        with pytest.raises(IndexError):
+            serialized[0]
+
+    def test_survives_pickle(self) -> None:
+        # DataLoader workers under the spawn start method pickle the dataset.
+        samples = _make_samples(3)
+        serialized = pickle.loads(pickle.dumps(SerializedSampleList(samples)))
+
+        assert len(serialized) == 3
+        assert serialized[2]["token"] == samples[2]["token"]
+
+    def test_forked_child_reads_shared_buffer(self) -> None:
+        samples = _make_samples(6)
+        serialized = SerializedSampleList(samples)
+        context = multiprocessing.get_context("fork")
+        queue = context.Queue()
+
+        def child(store, out) -> None:
+            out.put([sample["token"] for sample in store])
+
+        process = context.Process(target=child, args=(serialized, queue))
+        process.start()
+        tokens = queue.get(timeout=30)
+        process.join(timeout=30)
+
+        assert tokens == [sample["token"] for sample in samples]
+        assert process.exitcode == 0


### PR DESCRIPTION
## Problem

During multi-GPU StreamPETR training (2 GPUs × `num_workers=32`), training was unexpectedly terminated by the Linux OOM killer:

```text
[rank: 1] Child process ... terminated with code -9
```

This was **not a CUDA OOM**, but a **system RAM exhaustion** issue.

**Note**: The persistence worker is already set to **False** when this issue happened. A quick fix would be decreasing the number of workers.

### Root Cause

Each dataset stored annotations as a standard Python:

```python
self.data_infos: list[dict]
```

When `DataLoader(num_workers > 0)` is used on Linux, PyTorch launches worker
processes via **fork()**.

Initially, parent and child processes share memory through **copy-on-write (CoW)**,
so the dataset should theoretically occupy memory only once.

However, CPython stores the **reference count (`ob_refcnt`) inside every Python
object**. Every time a worker merely **reads** an element from
`list[dict]`, CPython increments and decrements its reference count,
which modifies the object's memory page.

As a result, the shared page becomes dirty and CoW creates a private copy for
that worker.

Therefore, each DataLoader worker gradually duplicates the annotation dataset,
even though it only performs read operations.

### Why It Became Fatal

The j6gen2 training annotation file is:

- **941 MB** on disk
- Approximately **5 GB** after being loaded into Python objects

With:

- 2 GPUs
- `num_workers = 32`

there are **64 worker processes**.

Worst-case memory usage becomes approximately:

```
64 × 5 GB ≈ 320 GB
```

The shared training machine only had **125 GB RAM**, so during epoch 3 the
kernel OOM killer terminated the training process.

## Solution

A new container class was introduced:

```
autoware_ml/datamodule/common/serialization.py
```

## `SerializedSampleList`

The implementation mirrors mmengine's serialization strategy.

Instead of storing:

```text
list
 ├── dict
 ├── dict
 ├── dict
 └── ...
```

samples are converted into:

```
+------------------------------+
| Serialized byte buffer       |
+------------------------------+

+------------------------------+
| int64 offset table           |
+------------------------------+
```

### Access Flow

```text
Dataset
      │
      ▼
SerializedSampleList
      │
      ├── contiguous pickle buffer
      ├── offset table
      ▼
__getitem__(i)
      │
      ▼
pickle.loads(buffer[start:end])
      ▼
fresh Python dict
```

Each sample is deserialized **only when accessed**.

Since the underlying storage is a byte array rather than millions of Python
objects, worker processes never modify shared pages during iteration.

The storage therefore remains shared across all forked workers.

### Properties

- Drop-in replacement for `list`
- Supports:
  - `len()`
  - integer indexing
- Returns independent Python objects
- No shared mutable state between workers

---

## Dataset Migration

The new container was applied to every dataset previously storing
`list[dict]`.

Serialization is performed **as the final step of `__init__`**, after all
operations requiring a full dataset traversal are complete.

These include:

- filtering
- `frame_weights`
- `prev_exists`
- any other preprocessing passes

## Updated datasets

- `common/multiview_detection3d.py`
  - additionally caches `scene_index_groups()` during initialization because
    samplers access it after worker processes are created
- `t4dataset/detection3d.py`
- `nuscenes/detection3d.py`
- `t4dataset/segmentation3d.py`
- `nuscenes/segmentation3d.py`
- `t4dataset/segdet.py`
- `nuscenes/segdet.py`
- `t4dataset/calibration_status.py`

---

## Verification

### Unit Tests

New test file:

```
tests/datamodule/test_serialization.py
```

Coverage includes:

- serialization/deserialization round-trip
- equality with original data
- negative indexing
- out-of-bound indexing
- iteration
- copy independence
- pickle round-trip
- forked worker shared-read behavior

---

### Test Results

```
542 tests passed
```


---

## Copy-on-Write Memory Measurement

The real validation dataset was used for measurement.

Dataset statistics:

- 3,215 frames
- approximately 270 MB live Python objects

Experiment:

- 4 forked worker processes
- every worker reads every sample twice
- garbage collection forced
- `Private_Dirty` measured using:

```
/proc/self/smaps_rollup
```

### Results

| Storage Layout | Private Memory per Worker |
|----------------|--------------------------:|
| `list[dict]` | 230 MB |
| `SerializedSampleList` | 7.4 MB |

The original implementation privatized roughly **85% of the dataset** for every
worker.

The serialized implementation remains nearly constant regardless of dataset size.

---

## Memory Reduction

| Metric | Result |
|---------|--------|
| Private memory per worker | **230 MB → 7.4 MB** |
| Reduction | **31× smaller** |

Extrapolating to the 5 GB training annotations:

| Layout | Estimated Memory @ 64 Workers |
|--------|------------------------------:|
| Original `list[dict]` | ~275–320 GB |
| `SerializedSampleList` | Nearly constant |

The estimate closely matches the observed Linux OOM event, while the serialized
implementation eliminates the copy-on-write memory explosion and allows
high-worker-count training to run successfully.