### PR TITLE
feat(ptv3): update transforms config and add NMS groups

### DIFF
--- a/autoware_ml/configs/tasks/detection3d/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
@@ -6,7 +6,7 @@ defaults:
   - /datasets/t4dataset/lidar
   - _self_
 
-batch_size: 4
+batch_size: 8
 num_workers: 8
 
 dataset: ${t4dataset}
@@ -36,9 +36,9 @@ datamodule:
         remove_close: true
       - _target_: autoware_ml.transforms.point_cloud.formatting.PreparePointCloudInput
       - _target_: autoware_ml.transforms.point_cloud.geometry.GlobalRotScaleTrans
-        rot_range: [-1.571, 1.571]
-        scale_ratio_range: [0.8, 1.2]
-        translation_std: [1.0, 1.0, 0.2]
+        rot_range: [-0.78539816, 0.78539816]
+        scale_ratio_range: [0.95, 1.05]
+        translation_std: [0.5, 0.5, 0.2]
       - _target_: autoware_ml.transforms.point_cloud.geometry.RandomFlip3D
         flip_ratio_bev_horizontal: 0.5
         flip_ratio_bev_vertical: 0.5
@@ -83,6 +83,11 @@ datamodule:
         point_cloud_range: ${point_cloud_range}
       - _target_: autoware_ml.transforms.boxes3d.filters.ObjectRangeFilter
         point_cloud_range: ${point_cloud_range}
+      - _target_: autoware_ml.transforms.boxes3d.filters.ObjectRangeMinPointsFilter
+        range_radius: [0.0, 60.0]
+        min_num_points: ${dataset.detection3d.train_min_points_near}
+      - _target_: autoware_ml.transforms.boxes3d.filters.ObjectRangeMinPointsFilter
+        range_radius: [60.0, 130.0]
       - _target_: autoware_ml.transforms.point_cloud.sampling.GridSample
         grid_size: ${grid_size}
         point_cloud_range: ${point_cloud_range}
@@ -170,7 +175,7 @@ model:
       voxel_size: [0.96, 0.96, 8.0]
       out_size_factor: 1
       post_center_range: [-132.88, -132.88, -5.0, 132.88, 132.88, 12.0]
-      score_threshold: 0.0
+      score_threshold: [0.015, 0.010, 0.010, 0.020, 0.030, 0.040, 0.020]
       code_size: 10
     assigner:
       _target_: autoware_ml.models.detection3d.task_modules.assigners.HungarianAssigner3D
@@ -194,6 +199,22 @@ model:
     score_threshold: 0.1
     post_max_size: 100
     nms_min_radius: 1.0
+    nms_groups:
+      - class_names: [car, truck, bus]
+        nms_radius: 0.25
+        post_max_size: 300
+      - class_names: [bicycle]
+        nms_radius: 0.0
+        post_max_size: 50
+      - class_names: [pedestrian]
+        nms_radius: 0.0
+        post_max_size: 100
+      - class_names: [traffic_cone]
+        nms_radius: 0.0
+        post_max_size: 100
+      - class_names: [barrier]
+        nms_radius: 0.0
+        post_max_size: 50
     loss_cls_weight: 1.0
     loss_bbox_weight: 0.25
     loss_heatmap_weight: 1.0

--- a/autoware_ml/configs/tasks/multi/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/multi/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
@@ -62,9 +62,9 @@ datamodule:
       - _target_: autoware_ml.transforms.point_cloud.formatting.PreparePointCloudInput
       - _target_: autoware_ml.transforms.segmentation3d.formatting.PreparePointSegInput
       - _target_: autoware_ml.transforms.point_cloud.geometry.GlobalRotScaleTrans
-        rot_range: [-1.571, 1.571]
-        scale_ratio_range: [0.8, 1.2]
-        translation_std: [1.0, 1.0, 0.2]
+        rot_range: [-0.78539816, 0.78539816]
+        scale_ratio_range: [0.95, 1.05]
+        translation_std: [0.5, 0.5, 0.2]
       - _target_: autoware_ml.transforms.point_cloud.geometry.RandomFlip3D
         flip_ratio_bev_horizontal: 0.5
         flip_ratio_bev_vertical: 0.5
@@ -115,6 +115,12 @@ datamodule:
         point_cloud_range: ${point_cloud_range}
       - _target_: autoware_ml.transforms.boxes3d.filters.ObjectRangeFilter
         point_cloud_range: ${point_cloud_range}
+      - _target_: autoware_ml.transforms.boxes3d.filters.ObjectRangeMinPointsFilter
+        range_radius: [0.0, 60.0]
+        min_num_points: ${dataset.detection3d.train_min_points_near}
+      - _target_: autoware_ml.transforms.boxes3d.filters.ObjectRangeMinPointsFilter
+        range_radius: [60.0, 130.0]
+        min_num_points: ${dataset.detection3d.train_min_points_far}
       - _target_: autoware_ml.transforms.common.copying.Copy
         keys_dict: { segment: origin_segment, coord: origin_coord }
       - _target_: autoware_ml.transforms.point_cloud.sampling.GridSample
@@ -158,5 +164,22 @@ model:
       output_shape: [256, 256]
   bbox_head:
     nms_min_radius: 1.0
+    nms_groups:
+      - class_names: [car, truck, bus]
+        nms_radius: 0.25
+        post_max_size: 300
+      - class_names: [bicycle]
+        nms_radius: 0.0
+        post_max_size: 50
+      - class_names: [pedestrian]
+        nms_radius: 0.0
+        post_max_size: 100
+      - class_names: [traffic_cone]
+        nms_radius: 0.0
+        post_max_size: 100
+      - class_names: [barrier]
+        nms_radius: 0.0
+        post_max_size: 50
     bbox_coder:
       post_center_range: [-132.88, -132.88, -5.0, 132.88, 132.88, 12.0]
+      score_threshold: [0.015, 0.010, 0.010, 0.020, 0.030, 0.040, 0.020]

--- a/autoware_ml/configs/tasks/segmentation3d/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/segmentation3d/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
@@ -7,7 +7,7 @@ defaults:
 
 dataset: ${t4dataset}
 
-batch_size: 8
+batch_size: 16
 num_workers: 8
 
 grid_size: 0.12


### PR DESCRIPTION
## Summary

- Aug: soften GlobalRotScaleTrans (smaller rotation, scale, translation)
- Train filter: add per-range ObjectRangeMinPointsFilter (near/far)
- NMS: add per-class nms_groups (circle-NMS for vehicles, none for small classes)
- Scoring: per-class score_threshold instead of a single global value
- Batch: bump det3d and seg3d batch sizes

## Related Issues

<!-- Link related issues or feature requests -->

## Checklist

- [ ] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [ ] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

## Additional Notes

<!-- Anything else reviewers should know? -->

## Additional Log and Media

<!-- Any additional logs or information. -->
