### PR TITLE
feat(ptv3): select nms type

### DIFF
--- a/autoware_ml/configs/tasks/detection3d/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
@@ -88,6 +88,7 @@ datamodule:
         min_num_points: ${dataset.detection3d.train_min_points_near}
       - _target_: autoware_ml.transforms.boxes3d.filters.ObjectRangeMinPointsFilter
         range_radius: [60.0, 130.0]
+        min_num_points: ${dataset.detection3d.train_min_points_far}
       - _target_: autoware_ml.transforms.point_cloud.sampling.GridSample
         grid_size: ${grid_size}
         point_cloud_range: ${point_cloud_range}
@@ -198,6 +199,7 @@ model:
     gaussian_overlap: 0.1
     score_threshold: 0.1
     post_max_size: 100
+    nms_type: circle
     nms_min_radius: 1.0
     nms_groups:
       - class_names: [car, truck, bus]

--- a/autoware_ml/configs/tasks/multi/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/multi/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
@@ -163,6 +163,7 @@ model:
     bev_projector:
       output_shape: [256, 256]
   bbox_head:
+    nms_type: circle
     nms_min_radius: 1.0
     nms_groups:
       - class_names: [car, truck, bus]


### PR DESCRIPTION
## Summary

Simply select NMS type for PTv3 test run. 
Also add missing threshold for det3d config for one of filter.

## Related Issues

<!-- Link related issues or feature requests -->

## Checklist

- [ ] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [ ] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

## Additional Notes

<!-- Anything else reviewers should know? -->

## Additional Log and Media

<!-- Any additional logs or information. -->
