### PR TITLE
Avoid PTv3 BEV projection NonZero export

### DIFF
--- a/autoware_ml/configs/tasks/detection3d/ptv3/bev_neck.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/bev_neck.yaml
@@ -10,6 +10,7 @@ bev_projector:
   in_channels: ${model.bev_neck.fusion.out_channels}
   out_channels: 128
   output_shape: ???
+  assume_valid_grid_coord: false
 bev_encoder:
   _target_: autoware_ml.models.detection3d.ptv3.PTv3BEVEncoder
   in_channels: ${model.bev_neck.bev_projector.out_channels}

--- a/autoware_ml/configs/tasks/detection3d/ptv3/voxel005_51m_nuscenes.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/voxel005_51m_nuscenes.yaml
@@ -137,6 +137,7 @@ model:
   bev_neck:
     bev_projector:
       output_shape: [256, 256]
+      assume_valid_grid_coord: true
   bbox_head:
     _target_: autoware_ml.models.detection3d.heads.transfusion.TransFusionHead
     num_proposals: ${num_proposals}

--- a/autoware_ml/configs/tasks/detection3d/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
@@ -152,6 +152,7 @@ model:
   bev_neck:
     bev_projector:
       output_shape: [256, 256]
+      assume_valid_grid_coord: true
   bbox_head:
     _target_: autoware_ml.models.detection3d.heads.transfusion.TransFusionHead
     num_proposals: ${num_proposals}

--- a/autoware_ml/configs/tasks/multi/ptv3/voxel005_51m_nuscenes.yaml
+++ b/autoware_ml/configs/tasks/multi/ptv3/voxel005_51m_nuscenes.yaml
@@ -140,6 +140,7 @@ model:
   bev_neck:
     bev_projector:
       output_shape: [256, 256]
+      assume_valid_grid_coord: true
   bbox_head:
     nms_min_radius: 1.0
     bbox_coder:

--- a/autoware_ml/configs/tasks/multi/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/multi/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
@@ -162,6 +162,7 @@ model:
   bev_neck:
     bev_projector:
       output_shape: [256, 256]
+      assume_valid_grid_coord: true
   bbox_head:
     nms_type: circle
     nms_min_radius: 1.0

--- a/autoware_ml/models/detection3d/ptv3.py
+++ b/autoware_ml/models/detection3d/ptv3.py
@@ -89,6 +89,7 @@ class PTv3BEVProjection(nn.Module):
         in_channels: int,
         out_channels: int,
         output_shape: Sequence[int],
+        assume_valid_grid_coord: bool = False,
     ) -> None:
         """Initialize the PTv3-to-BEV projection path.
 
@@ -96,10 +97,15 @@ class PTv3BEVProjection(nn.Module):
             in_channels: PTv3 point-feature dimension.
             out_channels: Dense BEV channel dimension.
             output_shape: Dense BEV shape as ``(height, width)``.
+            assume_valid_grid_coord: Skip BEV bounds filtering. Use only when
+                preprocessing guarantees all ``grid_coord`` values are within
+                ``output_shape``; this avoids data-dependent ``NonZero`` nodes
+                in exported ONNX graphs.
         """
         super().__init__()
         self.output_shape = tuple(int(value) for value in output_shape)
         self.out_channels = out_channels
+        self.assume_valid_grid_coord = assume_valid_grid_coord
         self.point_proj = nn.Sequential(
             nn.Linear(in_channels, out_channels, bias=False),
             nn.BatchNorm1d(out_channels),
@@ -136,16 +142,17 @@ class PTv3BEVProjection(nn.Module):
         batch_indices = offset_to_batch(offset, grid_coord)
         x_indices = grid_coord[:, 0].long()
         y_indices = grid_coord[:, 1].long()
-        valid_mask = (
-            (x_indices >= 0) & (x_indices < width) & (y_indices >= 0) & (y_indices < height)
-        )
-        if not torch.any(valid_mask):
-            return projected_features.new_zeros((batch_size, self.out_channels, height, width))
+        if not self.assume_valid_grid_coord:
+            valid_mask = (
+                (x_indices >= 0) & (x_indices < width) & (y_indices >= 0) & (y_indices < height)
+            )
+            if not torch.any(valid_mask):
+                return projected_features.new_zeros((batch_size, self.out_channels, height, width))
 
-        projected_features = projected_features[valid_mask]
-        batch_indices = batch_indices[valid_mask]
-        x_indices = x_indices[valid_mask]
-        y_indices = y_indices[valid_mask]
+            projected_features = projected_features[valid_mask]
+            batch_indices = batch_indices[valid_mask]
+            x_indices = x_indices[valid_mask]
+            y_indices = y_indices[valid_mask]
 
         flat_indices = batch_indices * (height * width) + y_indices * width + x_indices
         canvas = projected_features.new_zeros((batch_size * height * width, self.out_channels))

--- a/autoware_ml/tests/models/test_ptv3_detection.py
+++ b/autoware_ml/tests/models/test_ptv3_detection.py
@@ -19,6 +19,32 @@ from autoware_ml.tests.models.ptv3_detection_fixtures import (
 from autoware_ml.utils.checkpoints import apply_matching_weights
 
 
+def test_ptv3_bev_projection_assume_valid_matches_guarded_path_for_valid_coords() -> None:
+    guarded = build_trans_model().bev_neck.bev_projector.eval()
+    unguarded = build_trans_model().bev_neck.bev_projector.eval()
+    unguarded.load_state_dict(guarded.state_dict())
+    unguarded.assume_valid_grid_coord = True
+
+    expected_bev_shape = (8, 8)
+    assert guarded.output_shape == expected_bev_shape
+    bev_height, bev_width = expected_bev_shape
+
+    point_features = torch.randn(6, guarded.point_proj[0].in_features)
+    offset = torch.tensor([point_features.shape[0]], dtype=torch.long)
+    grid_coord = torch.tensor(
+        [[0, 0, 0], [1, 2, 0], [1, 2, 1], [3, 4, 0], [7, 7, 0], [5, 6, 2]],
+        dtype=torch.int32,
+    )
+    assert torch.all((grid_coord[:, 0] >= 0) & (grid_coord[:, 0] < bev_width))
+    assert torch.all((grid_coord[:, 1] >= 0) & (grid_coord[:, 1] < bev_height))
+
+    with torch.no_grad():
+        expected = guarded(point_features, grid_coord, offset)
+        actual = unguarded(point_features, grid_coord, offset)
+
+    assert torch.allclose(actual, expected)
+
+
 @pytest.mark.skipif(
     not IS_SPCONV_AVAILABLE or not torch.cuda.is_available(),
     reason="PTv3 sparse-convolution tests require CUDA spconv",

--- a/autoware_ml/tests/transforms/test_point_cloud.py
+++ b/autoware_ml/tests/transforms/test_point_cloud.py
@@ -79,15 +79,55 @@ class TestPointCloudTransforms:
     def test_points_range_filter(self):
         sample = {
             "points": np.array(
-                [[0.0, 0.0, 0.0], [5.0, 0.0, 0.0], [1.0, 1.0, 1.0]], dtype=np.float32
+                [
+                    [-1.0, -1.0, -1.0],
+                    [0.0, 0.0, 0.0],
+                    [2.0, 0.0, 0.0],
+                    [0.0, 2.0, 0.0],
+                    [0.0, 0.0, 2.0],
+                    [5.0, 0.0, 0.0],
+                    [1.0, 1.0, 1.0],
+                ],
+                dtype=np.float32,
             ),
-            "intensity": np.array([1.0, 2.0, 3.0], dtype=np.float32),
+            "intensity": np.arange(7, dtype=np.float32),
         }
 
         output = PointsRangeFilter(point_cloud_range=[-1.0, -1.0, -1.0, 2.0, 2.0, 2.0])(sample)
 
-        assert output["points"].shape[0] == 2
-        assert output["intensity"].shape[0] == 2
+        expected_points = np.array(
+            [[-1.0, -1.0, -1.0], [0.0, 0.0, 0.0], [1.0, 1.0, 1.0]], dtype=np.float32
+        )
+        assert np.allclose(output["points"], expected_points)
+        assert output["intensity"].tolist() == [0.0, 1.0, 6.0]
+
+    def test_points_range_filter_prevents_max_bound_grid_coords(self):
+        point_cloud_range = [0.0, 0.0, 0.0, 2.0, 2.0, 2.0]
+        sample = {
+            "coord": np.array(
+                [
+                    [0.0, 0.0, 0.0],
+                    [1.999, 1.999, 1.999],
+                    [2.0, 0.0, 0.0],
+                    [0.0, 2.0, 0.0],
+                    [0.0, 0.0, 2.0],
+                ],
+                dtype=np.float32,
+            )
+        }
+
+        ranged = PointsRangeFilter(point_cloud_range=point_cloud_range)(sample)
+        output = GridSample(
+            grid_size=1.0,
+            mode="test",
+            keys=("coord",),
+            return_grid_coord=True,
+            point_cloud_range=point_cloud_range,
+        )(ranged)
+
+        assert output["grid_coord"].shape == (2, 3)
+        assert np.all(output["grid_coord"] >= 0)
+        assert np.all(output["grid_coord"] < 2)
 
     def test_random_flip3d_updates_detection_boxes(self):
         sample = {

--- a/autoware_ml/transforms/point_cloud/crop.py
+++ b/autoware_ml/transforms/point_cloud/crop.py
@@ -119,7 +119,7 @@ class PointsRangeFilter(BaseTransform):
         points: npt.NDArray[np.float32] = input_dict[coord_key]
         lower = self.point_cloud_range[:3]
         upper = self.point_cloud_range[3:]
-        mask = ((points[:, :3] >= lower) & (points[:, :3] <= upper)).all(axis=1)
+        mask = ((points[:, :3] >= lower) & (points[:, :3] < upper)).all(axis=1)
         for key, value in list(input_dict.items()):
             if (
                 isinstance(value, np.ndarray)


### PR DESCRIPTION
## Summary

This PR adds an opt-in export path for the PTv3 detection BEV projector that skips BEV bounds-mask compaction when preprocessing already guarantees valid BEV grid coordinates.

The current guarded projection path exports boolean indexing as `NonZero` + `GatherND`, which TensorRT handles with data-dependent shape-host copies during detection-head inference. For the PTv3 multihead deployment configs, the point cloud is range-filtered/grid-sampled before the model, so the skip-stage BEV coordinates are expected to be inside the configured dense BEV canvas.

## Changes

- Add `assume_valid_grid_coord` to `PTv3BEVProjection`.
- Keep the default guarded behavior in the base BEV-neck config.
- Enable the unguarded export path for the PTv3 detection and multihead production configs.
- Add a focused test comparing guarded and unguarded projection outputs when all coordinates are valid.

## Benchmark Evidence

Measured on `sensing-bench` in isolation.

<img width="4901" height="1791" alt="image" src="https://github.com/user-attachments/assets/3a6a699f-28e3-46e8-b78e-03be9e03c102" />


| Check | Baseline | Optimized artifact check |
|---|---|---|
| Variant | `ptv3-0710-pipe251exp-807-baseline` | `ptv3-0710-pipe251exp-807-det-bev-no-nonzero` |
| GPU total replicate mean | `38.860 ms` | `38.749 ms` |
| Inference replicate mean | `35.872 ms` | `35.590 ms` |
| Nsight det-head enqueue max (CPU-side!) | `12.946 ms` | `2.618 ms` |
| BEV shape-sync signature | `NonZero_3[size][DevicetoShapeHostCopy]` max `8.997 ms` | no `NonZero`, no `DevicetoShapeHostCopy`, and no `trainStation` |
| Det-head ONNX op count | current exported graph includes `NonZero`/`GatherND` | `NonZero=0`, `GatherND=0`, `ScatterElements=1` |

## Validation

- TensorRT det-head engine rebuild from the optimized ONNX
- PTv3 7x50 benchmark series
- Nsight Systems profile analysis