### PR TITLE
fix(datamodule): fix datamodule for sweep transformation

### DIFF
--- a/autoware_ml/datamodule/common/detection3d.py
+++ b/autoware_ml/datamodule/common/detection3d.py
@@ -76,8 +76,11 @@ def build_sweep_entries(sample: Mapping[str, Any]) -> list[dict[str, Any]]:
     """Convert stored ``lidar_sweeps`` metadata into loader-ready sweep entries.
 
     Each entry carries the sweep point-cloud path, its timestamp, and the
-    rigid transform from the sweep lidar frame into the key lidar frame,
-    composed from the stored ego poses and lidar extrinsics.
+    rigid transform from the sweep lidar frame into the key lidar frame.
+
+    The precomputed ``lidar2sensor`` matrix (the key-lidar → sweep-lidar
+    transform including ego motion) is preferred when present. Recomposing the
+    transform from the stored ego poses is only a fallback
 
     Args:
         sample: Raw sample dictionary with ``lidar_points``, ``ego2global``,
@@ -94,15 +97,21 @@ def build_sweep_entries(sample: Mapping[str, Any]) -> list[dict[str, Any]]:
     if not lidar_sweeps:
         return []
 
-    key_lidar2ego = np.asarray(sample["lidar_points"]["lidar2ego"], dtype=np.float64)
-    key_ego2global = np.asarray(sample["ego2global"], dtype=np.float64)
-    global2key_lidar = np.linalg.inv(key_ego2global @ key_lidar2ego)
+    global2key_lidar = None
 
     entries = []
     for sweep in lidar_sweeps:
-        sweep_lidar2ego = np.asarray(sweep["lidar_points"]["lidar2ego"], dtype=np.float64)
-        sweep_ego2global = np.asarray(sweep["ego2global"], dtype=np.float64)
-        sweep2key_lidar = global2key_lidar @ sweep_ego2global @ sweep_lidar2ego
+        lidar2sensor = sweep["lidar_points"].get("lidar2sensor")
+        if lidar2sensor is not None:
+            sweep2key_lidar = np.linalg.inv(np.asarray(lidar2sensor, dtype=np.float64))
+        else:
+            if global2key_lidar is None:
+                key_lidar2ego = np.asarray(sample["lidar_points"]["lidar2ego"], dtype=np.float64)
+                key_ego2global = np.asarray(sample["ego2global"], dtype=np.float64)
+                global2key_lidar = np.linalg.inv(key_ego2global @ key_lidar2ego)
+            sweep_lidar2ego = np.asarray(sweep["lidar_points"]["lidar2ego"], dtype=np.float64)
+            sweep_ego2global = np.asarray(sweep["ego2global"], dtype=np.float64)
+            sweep2key_lidar = global2key_lidar @ sweep_ego2global @ sweep_lidar2ego
         entries.append(
             {
                 "lidar_path": sweep["lidar_points"]["lidar_path"],


### PR DESCRIPTION
## Description
`build_sweep_entries` in `autoware_ml/datamodule/common/detection3d.py`
recomposed the sweep → key-lidar transform from stored ego poses:
sweep2key = inv(key_ego2global @ key_lidar2ego) @ sweep_ego2global @ sweep_lidar2ego

This is correct only when the info file's sweep `lidar2ego` is the static
mounting extrinsic. Existing AWML-generated info files incorrectly stored the
sweep → key transform (which already contains ego motion) in that field, so
the composition applied ego motion twice and sweep point clouds were
misaligned — worse at higher ego speed.

## Fix

Prefer the precomputed `lidar2sensor` matrix (key → sweep, ego motion
included) stored per sweep and invert it to get `sweep2key`. This field has
always been correct, so the datamodule now produces aligned sweeps with both
old (buggy `lidar2ego`) and regenerated info files. Recomposing from ego
poses is kept only as a fallback when `lidar2sensor` is absent, and the
key-frame inverse is computed lazily in that path.

Related: AWML-side fix that corrects the `lidar2ego` field at info-generation
time https://github.com/tier4/AWML/pull/223). Either change alone fixes the misalignment; this one
additionally keeps existing pickle files usable without regeneration.

<!-- What does this PR do? -->

## Related Issues

<!-- Link related issues or feature requests -->

## Checklist

- [ ] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [ ] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

## Additional Notes

<!-- Anything else reviewers should know? -->

## Additional Log and Media

<!-- Any additional logs or information. -->
