### PR TITLE
fix(detection3d): pass gt_num_points through collation

### DIFF
--- a/autoware_ml/configs/tasks/detection3d/bevfusion/base.yaml
+++ b/autoware_ml/configs/tasks/detection3d/bevfusion/base.yaml
@@ -16,6 +16,7 @@ datamodule:
     points: list
     gt_boxes: list
     gt_labels: list
+    gt_num_points: list
 
 model:
   _target_: autoware_ml.models.detection3d.bevfusion.BEVFusionDetectionModel

--- a/autoware_ml/configs/tasks/detection3d/centerpoint/base.yaml
+++ b/autoware_ml/configs/tasks/detection3d/centerpoint/base.yaml
@@ -13,6 +13,7 @@ datamodule:
     points: list
     gt_boxes: list
     gt_labels: list
+    gt_num_points: list
 model:
   _target_: autoware_ml.models.detection3d.centerpoint.CenterPointDetectionModel
   metrics: ${dataset.detection3d.metrics}

--- a/autoware_ml/configs/tasks/detection3d/ptv3/base.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/base.yaml
@@ -33,6 +33,7 @@ datamodule:
     grid_coord: concat
     gt_boxes: list
     gt_labels: list
+    gt_num_points: list
 
 model:
   _target_: autoware_ml.models.detection3d.ptv3.PTv3DetectionModel

--- a/autoware_ml/configs/tasks/detection3d/transfusion/base.yaml
+++ b/autoware_ml/configs/tasks/detection3d/transfusion/base.yaml
@@ -14,6 +14,7 @@ datamodule:
     points: list
     gt_boxes: list
     gt_labels: list
+    gt_num_points: list
 model:
   _target_: autoware_ml.models.detection3d.transfusion.TransFusionDetectionModel
   metrics: ${dataset.detection3d.metrics}


### PR DESCRIPTION
## What

Adds `gt_num_points: list` to the `collation_map` of all four detection3d tasks
(bevfusion / centerpoint / transfusion / ptv3).

## Why

`Detection3DMetricSuite` is configured with `min_num_points: 2`, but its GT
filter only runs when `gt_num_points` is present in the eval output —
`gt_keep_mask` silently skips the check when the counts are `None`:

- `LoadBoxes3D` produces `gt_num_points` per sample ✓
- `detection_eval_output` reads it with `batch.get("gt_num_points")` ✓
- …but no detection3d `collation_map` whitelisted the key, so it never reached
  the batch, and **the configured min-points filter has never been applied**.

The only point-count filtering actually in effect was `use_valid_flag` at
loading (drops 0-point boxes), so every detection3d evaluation to date included
1-point GT boxes.

## Verification

BEVFusion-L j6gen2 val (3,645 frames), before → after this fix:

| class | evaluated GT before | after | removed (=1-point boxes) |
|---|---|---|---|
| car | 93,646 | 92,351 | 1,295 |
| pedestrian | 36,400 | 35,186 | 1,214 |
| traffic_cone | 3,926 | 3,583 | 343 |

After the fix the evaluated GT set matches the annotation-count filter class by
class (cross-checked against AWML T4MetricV2 with the same filter definition),
and 0–121 m mAP agrees between the two implementations to ±0.0004.

Expect a small upward shift in reported mAP versus historical runs (the
1-point boxes were almost never detectable); historical numbers are not
directly comparable to post-fix numbers.