### PR TITLE
feat(CenterPoint): Add vectorization to heatmap-related functions

### DIFF
--- a/autoware_ml/models/detection3d/task_modules/heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/heatmap.py
@@ -49,8 +49,8 @@ def batch_circle_nms(
     sorted_bboxes_centers = torch.gather(bboxes_centers, index=center_indices, dim=2)
 
     # Pairwise center distances.The matmul-based distance path is disabled to match the elementwise.
-    # (batch_size, num_classes, max_num_bboxes, 2) -> (batch_size, num_classes*max_num_bboxes, 2) ->
-    # (batch_size, num_classes, max_num_bboxes, max_num_bboxes)
+    # (batch_size, num_classes, max_num_bboxes, 2) -> (batch_size*num_classes, max_num_bboxes, 2) ->
+    # (batch_size * num_classes, max_num_bboxes, max_num_bboxes) -> (batch_size, num_classes, max_num_bboxes, max_num_bboxes)
     flatten_bboxes_centers = sorted_bboxes_centers.reshape(-1, max_num_bboxes, num_dimensions)
     pairwise_distances = torch.cdist(
         flatten_bboxes_centers,

--- a/autoware_ml/models/detection3d/task_modules/heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/heatmap.py
@@ -155,6 +155,9 @@ def _vectorize_gaussian2d(
     Padded with zeros for padded height and width values.
     """
     batch_size, max_num_boxes = heights.shape
+    if max_num_boxes == 0:
+        return torch.zeros((batch_size, 0, 0, 0), device=device, dtype=dtype)
+
     # Find the maximum height and width across the batch and boxes
     max_height = int(heights.max())
     max_width = int(widths.max())
@@ -288,7 +291,7 @@ def create_gaussian_heatmaps(
         (batch_size, num_classes, heatmap_height, heatmap_width), device=device, dtype=torch.float32
     )
 
-    # _vectorize_gaussian2d sizes every kernel slot from the global maximum diameter, 
+    # _vectorize_gaussian2d sizes every kernel slot from the global maximum diameter,
     # so a single large padded radius would inflate the padded kernel
     # tensor for the whole batch (and a negative one could shrink it below the valid boxes' needs).
     # Normalize invalid radii to zero, the smallest safe radius, so only valid boxes drive the

--- a/autoware_ml/models/detection3d/task_modules/heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/heatmap.py
@@ -24,7 +24,8 @@ def batch_circle_nms(
     This NMS checks only if two valid bboxes from the same classes heavily overlap by their
     L2 center distance without considering their box dimensions and orientations.
     Note that this NMS assumes bboxes from the same cluster/label share the same axis, for example,
-    all vehicles from the first batch are in [0, 0, :, :].
+    all vehicles from the first batch are in [0, 0, :, :]. Also, max_num_bboxes includes padded
+    boxes for each batch and class.
 
     Args:
         bboxes_centers: Decoded box centers in metric space.
@@ -39,7 +40,7 @@ def batch_circle_nms(
     batch_size, num_classes, max_num_bboxes = scores.shape
     num_dimensions = bboxes_centers.shape[-1]
 
-    # Invalid boxes always included
+    # max_num_bboxes includes padded boxes for each batch and class.
     # (batch_size, num_classes, max_num_bboxes)
     orders = scores.argsort(dim=2, descending=True, stable=True)
     sorted_bboxes_valid_masks = torch.gather(valid_bboxes_masks, index=orders, dim=2)

--- a/autoware_ml/models/detection3d/task_modules/heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/heatmap.py
@@ -214,7 +214,6 @@ def create_gaussian_heatmaps(
     heatmap_width: int,
     heatmap_height: int,
     num_classes: int,
-    batch_size: int,
     centers: Int64[torch.Tensor, "batch_size max_num_boxes 2"],
     gaussian_radii: Int32[torch.Tensor, "batch_size max_num_boxes"],
     gt_bboxes_labels: Int64[torch.Tensor, "batch_size max_num_boxes"],
@@ -268,7 +267,6 @@ def create_gaussian_heatmaps(
         heatmap_width: Width of the heatmap.
         heatmap_height: Height of the heatmap.
         num_classes: Number of classes.
-        batch_size: Batch size.
         centers: Heatmap centers as ``(x, y)`` for each box.
         gaussian_radii: Gaussian radius in pixels for each box.
         gt_bboxes_labels: Class labels for each bounding box.
@@ -278,6 +276,11 @@ def create_gaussian_heatmaps(
     Returns:
         Heatmap tensor of shape ``(batch_size, num_classes, heatmap_height, heatmap_width)``.
     """
+    batch_size = centers.shape[0]
+    if batch_size != gaussian_radii.shape[0] or batch_size != gt_bboxes_labels.shape[0]:
+        raise ValueError(
+            "Batch size mismatch: centers, gaussian_radii, and gt_bboxes_labels must have the same batch size."
+        )
     heatmaps = torch.zeros(
         (batch_size, num_classes, heatmap_height, heatmap_width), device=device, dtype=torch.float32
     )

--- a/autoware_ml/models/detection3d/task_modules/heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/heatmap.py
@@ -288,8 +288,8 @@ def create_gaussian_heatmaps(
         (batch_size, num_classes, heatmap_height, heatmap_width), device=device, dtype=torch.float32
     )
 
-    # Radii of padded boxes are arbitrary, but _vectorize_gaussian2d sizes every kernel slot from
-    # the global maximum diameter, so a single large padded radius would inflate the padded kernel
+    # _vectorize_gaussian2d sizes every kernel slot from the global maximum diameter, 
+    # so a single large padded radius would inflate the padded kernel
     # tensor for the whole batch (and a negative one could shrink it below the valid boxes' needs).
     # Normalize invalid radii to zero, the smallest safe radius, so only valid boxes drive the
     # kernel size. Invalid boxes still contribute nothing, because valid_masks zeroes them out.

--- a/autoware_ml/models/detection3d/task_modules/heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/heatmap.py
@@ -15,21 +15,20 @@ import torch
 def batch_circle_nms(
     bboxes_centers: Float32[torch.Tensor, "batch_size num_classes max_num_boxes 2"],
     scores: Float32[torch.Tensor, "batch_size num_classes max_num_boxes"],
-    bboxes_labels: Int64[torch.Tensor, "batch_size num_classes max_num_boxes"],
     min_radius: float,
     valid_bboxes_masks: Bool[torch.Tensor, "batch_size num_classes max_num_boxes"],
     post_max_size: int,
 ) -> Bool[torch.Tensor, "batch_size num_classes max_num_boxes"]:
     """
-    Apply greedy center-distance NMS across batch and classes in the BEV plane.
+    Apply greedy center-distance NMS for each batch and classes in the BEV plane.
     This NMS checks only if two valid bboxes from the same classes heavily overlap by their
     L2 center distance without considering their box dimensions and orientations.
-    Note that this NMS assumes bboxes is ordered by classes.
+    Note that this NMS assumes bboxes from the same cluster/label share the same axis, for example,
+    all vehicles from the first batch are in [0, 0, :, :].
 
     Args:
         bboxes_centers: Decoded box centers in metric space.
         scores: Confidence scores for the boxes.
-        bboxes_labels: Labels for the boxes.
         min_radius: Minimum center distance for suppression.
         valid_bboxes_masks: Boolean mask indicating which boxes are valid and should be considered for NMS.
         post_max_size: Maximum number of boxes kept after suppression, counted per class.
@@ -44,7 +43,6 @@ def batch_circle_nms(
     # (batch_size, num_classes, max_num_bboxes)
     orders = scores.argsort(dim=2, descending=True, stable=True)
     sorted_bboxes_valid_masks = torch.gather(valid_bboxes_masks, index=orders, dim=2)
-    sorted_bboxes_labels = torch.gather(bboxes_labels, index=orders, dim=2)
     # (batch_size, num_classes, max_num_bboxes) -> (batch_size, num_classes, max_num_bboxes, 2)
     center_indices = orders.unsqueeze(-1).expand(-1, -1, -1, num_dimensions)
     sorted_bboxes_centers = torch.gather(bboxes_centers, index=center_indices, dim=2)
@@ -60,13 +58,9 @@ def batch_circle_nms(
         compute_mode="donot_use_mm_for_euclid_dist",
     ).view(batch_size, num_classes, max_num_bboxes, max_num_bboxes)
 
-    # A pair may only suppress when both boxes share a label.
-    # (batch_size, num_classes, max_num_bboxes, max_num_bboxes)
-    pairwise_labels = sorted_bboxes_labels.unsqueeze(-1) == sorted_bboxes_labels.unsqueeze(-2)
-
     # Keeps a box only when its center distance is strictly greater than min_radius.
     # (batch_size, num_classes, max_num_bboxes, max_num_bboxes)
-    pairwise_suppression = (pairwise_distances <= min_radius) & pairwise_labels
+    pairwise_suppression = pairwise_distances <= min_radius
 
     # Only a higher scoring box may suppress a lower scoring one. After the descending sort
     # that is exactly the strict upper triangle.

--- a/autoware_ml/models/detection3d/task_modules/heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/heatmap.py
@@ -256,7 +256,9 @@ def create_gaussian_heatmaps(
           are zeroed in step 3, and zeros never beat the (non-negative) heatmap
           under ``amax``. Padding labels such as ``-1`` are safe via clamping.
         - Memory scales with ``B * N * max_diameter**2``; a single large radius
-          in the batch inflates the padded kernel tensor for all boxes.
+          in the batch inflates the padded kernel tensor for all boxes. Only
+          valid boxes count: radii of invalid (padded) boxes are normalized to
+          zero first, so they never drive the kernel size.
         - A box whose center lies outside the heatmap is expected to be marked
           invalid in ``valid_masks`` (the caller filters these via a center-in-bounds check).
           Such boxes contribute nothing, matching the scalar reference. The per-cell ``in_bounds``
@@ -268,7 +270,8 @@ def create_gaussian_heatmaps(
         heatmap_height: Height of the heatmap.
         num_classes: Number of classes.
         centers: Heatmap centers as ``(x, y)`` for each box.
-        gaussian_radii: Gaussian radius in pixels for each box.
+        gaussian_radii: Gaussian radius in pixels for each box. Radii of boxes marked invalid in
+            ``valid_masks`` are ignored, so callers need not pad them with any particular value.
         gt_bboxes_labels: Class labels for each bounding box.
         valid_masks: Mask indicating valid bounding boxes.
         device: Torch device.
@@ -285,8 +288,18 @@ def create_gaussian_heatmaps(
         (batch_size, num_classes, heatmap_height, heatmap_width), device=device, dtype=torch.float32
     )
 
+    # Radii of padded boxes are arbitrary, but _vectorize_gaussian2d sizes every kernel slot from
+    # the global maximum diameter, so a single large padded radius would inflate the padded kernel
+    # tensor for the whole batch (and a negative one could shrink it below the valid boxes' needs).
+    # Normalize invalid radii to zero, the smallest safe radius, so only valid boxes drive the
+    # kernel size. Invalid boxes still contribute nothing, because valid_masks zeroes them out.
     # (batch_size, max_num_boxes)
-    diameters = 2 * gaussian_radii + 1
+    normalized_gaussian_radii = torch.where(
+        valid_masks.bool(), gaussian_radii, torch.zeros_like(gaussian_radii)
+    )
+
+    # (batch_size, max_num_boxes)
+    diameters = 2 * normalized_gaussian_radii + 1
 
     # (batch_size, max_num_boxes, max_height, max_width)
     batch_gaussians_2d = _vectorize_gaussian2d(
@@ -305,11 +318,13 @@ def create_gaussian_heatmaps(
     # (0, 1, 2, ..., max_diameter-1)
     idx = torch.arange(max_diameter, device=device)  # (max_diameter,)
 
+    # The normalized radii keep the coordinates of padded boxes in a sane range; their cells are
+    # dropped by valid_masks in in_bounds regardless.
     # (B, max_num_bboxes, 1) - (B, max_num_bboxes, 1) + (1, 1, max_diameter) -> (B, N, max_diameter)
     # From [center_y - radius, center_y + radius], for each box, broadcast to all boxes in the batch
-    ys = centers[..., 1].unsqueeze(-1) - gaussian_radii.unsqueeze(-1) + idx
+    ys = centers[..., 1].unsqueeze(-1) - normalized_gaussian_radii.unsqueeze(-1) + idx
     # From [center_x - radius, center_x + radius], for each box, broadcast to all boxes in the batch
-    xs = centers[..., 0].unsqueeze(-1) - gaussian_radii.unsqueeze(-1) + idx
+    xs = centers[..., 0].unsqueeze(-1) - normalized_gaussian_radii.unsqueeze(-1) + idx
 
     # meshgrid to get all combinations of (y, x) for each box in the batch
     # (B, max_num_bboxes, max_diameter, 1) -> (B, max_num_bboxes, max_diameter, max_diameter)

--- a/autoware_ml/models/detection3d/task_modules/heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/heatmap.py
@@ -270,7 +270,7 @@ def create_gaussian_heatmaps(
         num_classes: Number of classes.
         batch_size: Batch size.
         centers: Heatmap centers as ``(x, y)`` for each box.
-        gaussian_radius: Gaussian radius in pixels for each box.
+        gaussian_radii: Gaussian radius in pixels for each box.
         gt_bboxes_labels: Class labels for each bounding box.
         valid_masks: Mask indicating valid bounding boxes.
         device: Torch device.

--- a/autoware_ml/models/detection3d/task_modules/heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/heatmap.py
@@ -51,7 +51,9 @@ def batch_circle_nms(
     # Pairwise center distances.The matmul-based distance path is disabled to match the elementwise.
     # (batch_size, num_classes, max_num_bboxes, 2) -> (batch_size*num_classes, max_num_bboxes, 2) ->
     # (batch_size * num_classes, max_num_bboxes, max_num_bboxes) -> (batch_size, num_classes, max_num_bboxes, max_num_bboxes)
-    flatten_bboxes_centers = sorted_bboxes_centers.reshape(-1, max_num_bboxes, num_dimensions)
+    flatten_bboxes_centers = sorted_bboxes_centers.reshape(
+        batch_size * num_classes, max_num_bboxes, num_dimensions
+    )
     pairwise_distances = torch.cdist(
         flatten_bboxes_centers,
         flatten_bboxes_centers,

--- a/autoware_ml/models/detection3d/task_modules/heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/heatmap.py
@@ -355,8 +355,15 @@ def create_gaussian_heatmaps(
 
     # Labels for each box, shape (B, N, 1, 1)
     labels = gt_bboxes_labels.view(batch_size, max_num_bboxes, 1, 1)
+    # Check if labels are more than num_classes, if so, raise an error
+    if (labels >= num_classes).any():
+        raise ValueError(
+            f"Found label(s) >= num_classes ({num_classes}). "
+            "Please ensure that all labels are in the range [0, num_classes - 1]."
+        )
+
     # clamp invalid labels (e.g. -1 padding) so indexing stays legal;
-    clamp_labels = labels.clamp(min=0, max=num_classes - 1)
+    clamp_labels = labels.clamp(min=0)
 
     # (B, max_num_bboxes, 1, 1) + (B, max_num_bboxes, max_diameter, max_diameter) -> (B, max_num_bboxes, max_diameter, max_diameter)
     flat_idx = (

--- a/autoware_ml/models/detection3d/task_modules/heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/heatmap.py
@@ -48,7 +48,8 @@ def batch_circle_nms(
     center_indices = orders.unsqueeze(-1).expand(-1, -1, -1, num_dimensions)
     sorted_bboxes_centers = torch.gather(bboxes_centers, index=center_indices, dim=2)
 
-    # Pairwise center distances.The matmul-based distance path is disabled to match the elementwise.
+    # Pairwise center distances. compute_mode disables the matmul-based path so distances
+    # are computed elementwise.
     # (batch_size, num_classes, max_num_bboxes, 2) -> (batch_size*num_classes, max_num_bboxes, 2) ->
     # (batch_size * num_classes, max_num_bboxes, max_num_bboxes) -> (batch_size, num_classes, max_num_bboxes, max_num_bboxes)
     flatten_bboxes_centers = sorted_bboxes_centers.reshape(

--- a/autoware_ml/models/detection3d/task_modules/heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/heatmap.py
@@ -120,7 +120,7 @@ def vectorize_gaussian_radii(
         min_overlap: Minimum Gaussian overlap with the target box.
 
     Returns:
-        Gaussian (2D) radius in meters.
+        Gaussian (2D) radius in feature-map cells.
     """
     a1 = 1
     b1 = heights + widths

--- a/autoware_ml/models/detection3d/task_modules/heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/heatmap.py
@@ -6,9 +6,359 @@ shared by CenterPoint-style dense heads.
 
 from __future__ import annotations
 
+from jaxtyping import Bool, Float32, Int32, Int64
 import math
 
 import torch
+
+
+def batch_circle_nms(
+    bboxes_centers: Float32[torch.Tensor, "batch_size num_classes max_num_boxes 2"],
+    scores: Float32[torch.Tensor, "batch_size num_classes max_num_boxes"],
+    bboxes_labels: Int64[torch.Tensor, "batch_size num_classes max_num_boxes"],
+    min_radius: float,
+    valid_bboxes_masks: Bool[torch.Tensor, "batch_size num_classes max_num_boxes"],
+    post_max_size: int,
+) -> Bool[torch.Tensor, "batch_size num_classes max_num_boxes"]:
+    """
+    Apply greedy center-distance NMS across batch and classes in the BEV plane.
+    This NMS checks only if two valid bboxes from the same classes heavily overlap by their
+    L2 center distance without considering their box dimensions and orientations.
+    Note that this NMS assumes bboxes is ordered by classes.
+
+    Args:
+        bboxes_centers: Decoded box centers in metric space.
+        scores: Confidence scores for the boxes.
+        bboxes_labels: Labels for the boxes.
+        min_radius: Minimum center distance for suppression.
+        valid_bboxes_masks: Boolean mask indicating which boxes are valid and should be considered for NMS.
+        post_max_size: Maximum number of boxes kept after suppression, counted per class.
+
+    Returns:
+        Boolean mask of the boxes kept after suppression, aligned with the input order.
+    """
+    batch_size, num_classes, max_num_bboxes = scores.shape
+    num_dimensions = bboxes_centers.shape[-1]
+
+    # Invalid boxes always included
+    # (batch_size, num_classes, max_num_bboxes)
+    orders = scores.argsort(dim=2, descending=True, stable=True)
+    sorted_bboxes_valid_masks = torch.gather(valid_bboxes_masks, index=orders, dim=2)
+    sorted_bboxes_labels = torch.gather(bboxes_labels, index=orders, dim=2)
+    # (batch_size, num_classes, max_num_bboxes) -> (batch_size, num_classes, max_num_bboxes, 2)
+    center_indices = orders.unsqueeze(-1).expand(-1, -1, -1, num_dimensions)
+    sorted_bboxes_centers = torch.gather(bboxes_centers, index=center_indices, dim=2)
+
+    # Pairwise center distances.The matmul-based distance path is disabled to match the elementwise.
+    # (batch_size, num_classes, max_num_bboxes, 2) -> (batch_size, num_classes*max_num_bboxes, 2) ->
+    # (batch_size, num_classes, max_num_bboxes, max_num_bboxes)
+    flatten_bboxes_centers = sorted_bboxes_centers.reshape(-1, max_num_bboxes, num_dimensions)
+    pairwise_distances = torch.cdist(
+        flatten_bboxes_centers,
+        flatten_bboxes_centers,
+        p=2.0,
+        compute_mode="donot_use_mm_for_euclid_dist",
+    ).view(batch_size, num_classes, max_num_bboxes, max_num_bboxes)
+
+    # A pair may only suppress when both boxes share a label.
+    # (batch_size, num_classes, max_num_bboxes, max_num_bboxes)
+    pairwise_labels = sorted_bboxes_labels.unsqueeze(-1) == sorted_bboxes_labels.unsqueeze(-2)
+
+    # Keeps a box only when its center distance is strictly greater than min_radius.
+    # (batch_size, num_classes, max_num_bboxes, max_num_bboxes)
+    pairwise_suppression = (pairwise_distances <= min_radius) & pairwise_labels
+
+    # Only a higher scoring box may suppress a lower scoring one. After the descending sort
+    # that is exactly the strict upper triangle.
+    # Setting triu(diagonal=1) ensures that a box does not suppress itself.
+    # (max_num_bboxes, max_num_bboxes)
+    higher_score_masks = torch.ones(
+        (max_num_bboxes, max_num_bboxes), dtype=torch.bool, device=scores.device
+    ).triu(diagonal=1)
+    pairwise_suppression &= higher_score_masks.view(1, 1, max_num_bboxes, max_num_bboxes)
+
+    # Greedy suppression is sequential by nature, because whether a box survives depends on
+    # previous suppression results, for example, A -> B -> C, where A suppresses B and B suppresses
+    # C, but A does not suppress C directly.
+    # (batch_size, num_classes, max_num_bboxes)
+    candidate_masks = sorted_bboxes_valid_masks.clone()
+    sorted_keep_masks = torch.zeros_like(candidate_masks)
+
+    # Loop over bboxes across batch and class dimensions.
+    for rank in range(max_num_bboxes):
+        # First, move the valid status of the current rank to the keep mask.
+        # (batch_size, num_classes)
+        kept_masks = candidate_masks[:, :, rank]
+        sorted_keep_masks[:, :, rank] = kept_masks
+        # Next, check if the current rank suppresses any bboxes.
+        # (kept_masks.unsqueeze(-1) & pairwise_suppression[:, :, rank, :]) is only True when the
+        # current rank is valid and it suppresses other bboxes.
+        # Then, it negates the suppression result to mark the suppressed bboxes as invalid or valid
+        # for the next rank.
+        candidate_masks &= ~(kept_masks.unsqueeze(-1) & pairwise_suppression[:, :, rank, :])
+
+    # Accumulate sum for each class to ensure that no more than post_max_size boxes
+    # are kept per class.
+    # (batch_size, num_classes, max_num_bboxes)
+    sorted_keep_masks &= sorted_keep_masks.cumsum(dim=2) <= post_max_size
+
+    # Inverse the order to get the original index of each bbox in the unsorted position.
+    inverse_orders = orders.argsort(dim=2, stable=True)
+    # (batch_size, num_classes, max_num_bboxes)
+    keep_masks = torch.gather(sorted_keep_masks, index=inverse_orders, dim=2)
+    return keep_masks.bool()
+
+
+def vectorize_gaussian_radii(
+    widths: Float32[torch.Tensor, "batch_size max_num_boxes"],
+    heights: Float32[torch.Tensor, "batch_size max_num_boxes"],
+    min_overlap: float = 0.1,
+) -> Int32[torch.Tensor, "batch_size max_num_boxes"]:
+    """
+    Compute the Gaussian radius used for dense heatmap supervision in a vectorized manner
+    The formula is symmetric, so callers may pass either axis for height and width order
+    consistently.
+
+    Args:
+        widths: Box widths in meters.
+        heights: Box heights in meters.
+        min_overlap: Minimum Gaussian overlap with the target box.
+
+    Returns:
+        Gaussian (2D) radius in meters.
+    """
+    a1 = 1
+    b1 = heights + widths
+    c1 = widths * heights * (1 - min_overlap) / (1 + min_overlap)
+    sq1 = torch.sqrt(torch.clamp(b1**2 - 4 * a1 * c1, min=0.0))
+    r1 = (b1 + sq1) / 2
+
+    a2 = 4
+    b2 = 2 * (heights + widths)
+    c2 = (1 - min_overlap) * widths * heights
+    sq2 = torch.sqrt(torch.clamp(b2**2 - 4 * a2 * c2, min=0.0))
+    r2 = (b2 + sq2) / 2
+
+    a3 = 4 * min_overlap
+    b3 = -2 * min_overlap * (heights + widths)
+    c3 = (min_overlap - 1) * widths * heights
+    sq3 = torch.sqrt(torch.clamp(b3**2 - 4 * a3 * c3, min=0.0))
+    r3 = (b3 + sq3) / 2
+    return torch.minimum(torch.minimum(r1, r2), r3).to(torch.int32)
+
+
+def _vectorize_gaussian2d(
+    heights: Int32[torch.Tensor, "batch_size max_num_boxes"],
+    widths: Int32[torch.Tensor, "batch_size max_num_boxes"],
+    sigmas: Float32[torch.Tensor, "batch_size max_num_boxes"],
+    valid_masks: Bool[torch.Tensor, "batch_size max_num_boxes"],
+    device: torch.device,
+    dtype: torch.dtype,
+) -> Float32[torch.Tensor, "batch_size max_num_boxes max_height max_width"]:
+    """
+    Create a 2D Gaussian kernel based on the maximum of height and width over the batch and boxes.
+    Padded with zeros for padded height and width values.
+    """
+    batch_size, max_num_boxes = heights.shape
+    # Find the maximum height and width across the batch and boxes
+    max_height = int(heights.max())
+    max_width = int(widths.max())
+
+    # (max_height)
+    ys = torch.arange(max_height, device=device, dtype=dtype)
+    # (max_width)
+    xs = torch.arange(max_width, device=device, dtype=dtype)
+
+    batch_heights = heights.view(batch_size, max_num_boxes, 1, 1)  # (B, M, 1, 1)
+    batch_widths = widths.view(batch_size, max_num_boxes, 1, 1)  # (B, M, 1, 1)
+
+    # per-box centered coordinates: y in [-(h-1)/2, (h-1)/2], same for x [-(w-1)/2, (w-1)/2]
+    # (1, 1, max_height, 1) - (B, M, 1, 1) -> (B, M, max_height, 1)
+    y = ys.view(1, 1, max_height, 1) - (batch_heights - 1) / 2  # (B, N, H, 1)
+    # (1, 1, 1, max_width) - (B, M, 1, 1) -> (B, M, 1, max_width)
+    x = xs.view(1, 1, 1, max_width) - (batch_widths - 1) / 2  # (B, N, 1, W)
+
+    # Update sigmas to set invalid sigmas to 1.0 to avoid NaNs in the Gaussian computation
+    # avoid in-place mutation of the sigmas tensor
+    updated_sigmas = torch.where(valid_masks.bool(), sigmas, torch.ones_like(sigmas)).view(
+        batch_size, max_num_boxes, 1, 1
+    )
+
+    # (B, M, max_height, 1) * (B, M, 1, max_width) -> (B, M, max_height, max_width)
+    # (B, M, max_height, max_width) / (B, M) -> (B, M, max_height, max_width)
+    # (B, N, max_height, max_width)
+    gaussian = torch.exp(-(x * x + y * y) / (2 * updated_sigmas * updated_sigmas))
+
+    # zero everything outside each box's own h×w region
+    # (1, 1, max_height, 1) < (B, M, 1, 1) -> (B, M, max_height, 1) &
+    # (1, 1, 1, max_width) < (B, M, 1, 1) -> (B, M, 1, max_width) ->
+    # (B, M, max_height, max_width), where 1.0 means inside the box's own h×w region, 0.0 means outside
+    inside_size = (ys.view(1, 1, max_height, 1) < batch_heights) & (
+        xs.view(1, 1, 1, max_width) < batch_widths
+    )
+    gaussian = gaussian * inside_size
+
+    # Set gaussian for invalid boxes to zero
+    gaussian = gaussian * valid_masks.view(
+        batch_size, max_num_boxes, 1, 1
+    )  # (B, M, max_height, max_width)
+
+    # threshold against each kernel's own max (not the global max)
+    # (B, M, max_height, max_width) -> (B, M, max_height*max_width) -> (B, M) -> (B, M, 1, 1)
+    kernel_max = gaussian.flatten(2).amax(dim=-1).view(batch_size, max_num_boxes, 1, 1)
+    # Find out maximum value of the gaussian kernel for each box and threshold against it
+    gaussian = torch.where(
+        gaussian < torch.finfo(dtype).eps * kernel_max,
+        torch.zeros_like(gaussian),
+        gaussian,
+    )
+    return gaussian
+
+
+def create_gaussian_heatmaps(
+    heatmap_width: int,
+    heatmap_height: int,
+    num_classes: int,
+    batch_size: int,
+    centers: Int64[torch.Tensor, "batch_size max_num_boxes 2"],
+    gaussian_radii: Int32[torch.Tensor, "batch_size max_num_boxes"],
+    gt_bboxes_labels: Int64[torch.Tensor, "batch_size max_num_boxes"],
+    valid_masks: Bool[torch.Tensor, "batch_size max_num_boxes"],
+    device: torch.device,
+) -> Float32[torch.Tensor, "batch_size num_classes heatmap_height heatmap_width"]:
+    """
+    Create per-class heatmaps with Gaussian blobs for all valid boxes, fully vectorized
+    in a batch.
+
+    For each valid box, a 2D Gaussian kernel of size ``diameter = (2 * radius + 1)`` with
+    ``sigma = diameter / 6`` is drawn onto the heatmap channel of its class label,
+    centered at the given ``(x, y)`` center. Where blobs overlap (or a blob overlaps
+    existing values), the element-wise maximum is kept, matching the standard max-splat.
+
+    Algorithm:
+      1. Batched kernel generation: ``_vectorize_gaussian2d`` builds all kernels
+         at once, padded to a common shape
+         ``(batch_size, max_num_boxes, max_diameter, max_diameter)``. Each kernel
+         occupies the top-left ``diameter x diameter`` (diameter from each bbox)
+         corner of its slot. The invalid bbox and padding are set to zero.
+      2. Coordinate mapping: for every kernel cell, its global heatmap coordinate
+         is computed as ``center - radius + cell_index``, broadcast to a
+         ``(batch_size, max_num_boxes, max_diameter, max_diameter)`` grid of ``(yy, xx)`` positions.
+      3. Masking: cells that fall outside the heatmap, or belong to an invalid
+         (padded) box per ``valid_masks``, have their Gaussian value set to zero.
+         Out-of-heatmap parts of a blob are therefore clipped per-cell, while the
+         in-heatmap remainder is still drawn.
+      4. Flat indexing: each cell's target position is linearized as
+         ``label * H * W + y * W + x`` into a per-sample flat buffer of size
+         ``num_classes * H * W``. Labels and coordinates are clamped into valid
+         range so indexing is always legal; clamped cells carry value zero and
+         cannot win the max.
+      5. Scatter: a single ``scatter_reduce_(reduce="amax", include_self=True)``
+         writes all cells for the whole batch, resolving overlaps between boxes
+         and with pre-existing heatmap values by maximum.
+
+    Notes:
+        - Invalid boxes (``valid_masks == 0``) contribute nothing: their values
+          are zeroed in step 3, and zeros never beat the (non-negative) heatmap
+          under ``amax``. Padding labels such as ``-1`` are safe via clamping.
+        - Memory scales with ``B * N * max_diameter**2``; a single large radius
+          in the batch inflates the padded kernel tensor for all boxes.
+        - A box whose center lies outside the heatmap is expected to be marked
+          invalid in ``valid_masks`` (the caller filters these via a center-in-bounds check).
+          Such boxes contribute nothing, matching the scalar reference. The per-cell ``in_bounds``
+          clipping then only handles blob *tails* of valid boxes that extend past the
+          heatmap border, which are clipped cell-by-cell.
+
+    Args:
+        heatmap_width: Width of the heatmap.
+        heatmap_height: Height of the heatmap.
+        num_classes: Number of classes.
+        batch_size: Batch size.
+        centers: Heatmap centers as ``(x, y)`` for each box.
+        gaussian_radius: Gaussian radius in pixels for each box.
+        gt_bboxes_labels: Class labels for each bounding box.
+        valid_masks: Mask indicating valid bounding boxes.
+        device: Torch device.
+
+    Returns:
+        Heatmap tensor of shape ``(batch_size, num_classes, heatmap_height, heatmap_width)``.
+    """
+    heatmaps = torch.zeros(
+        (batch_size, num_classes, heatmap_height, heatmap_width), device=device, dtype=torch.float32
+    )
+
+    # (batch_size, max_num_boxes)
+    diameters = 2 * gaussian_radii + 1
+
+    # (batch_size, max_num_boxes, max_height, max_width)
+    batch_gaussians_2d = _vectorize_gaussian2d(
+        heights=diameters,
+        widths=diameters,
+        sigmas=diameters / 6.0,
+        valid_masks=valid_masks,
+        device=device,
+        dtype=torch.float32,
+    )
+
+    # max_diameter == max_height == max_width since it uses the same diameters
+    _, max_num_bboxes, max_diameter, _ = batch_gaussians_2d.shape
+
+    # global pixel coordinates of every kernel cell
+    # (0, 1, 2, ..., max_diameter-1)
+    idx = torch.arange(max_diameter, device=device)  # (max_diameter,)
+
+    # (B, max_num_bboxes, 1) - (B, max_num_bboxes, 1) + (1, 1, max_diameter) -> (B, N, max_diameter)
+    # From [center_y - radius, center_y + radius], for each box, broadcast to all boxes in the batch
+    ys = centers[..., 1].unsqueeze(-1) - gaussian_radii.unsqueeze(-1) + idx
+    # From [center_x - radius, center_x + radius], for each box, broadcast to all boxes in the batch
+    xs = centers[..., 0].unsqueeze(-1) - gaussian_radii.unsqueeze(-1) + idx
+
+    # meshgrid to get all combinations of (y, x) for each box in the batch
+    # (B, max_num_bboxes, max_diameter, 1) -> (B, max_num_bboxes, max_diameter, max_diameter)
+    # All y-coordinates of the kernel cells for each box in the batch, broadcast to all x-coordinates
+    yy = ys.unsqueeze(-1).expand(batch_size, max_num_bboxes, max_diameter, max_diameter)
+    # (B, max_num_bboxes, max_diameter, 1) -> (B, max_num_bboxes, max_diameter, max_diameter)
+    # All x-coordinates of the kernel cells for each box in the batch, broadcast to all y-coordinates
+    xx = xs.unsqueeze(-2).expand(batch_size, max_num_bboxes, max_diameter, max_diameter)
+
+    # (B, max_num_bboxes, max_diameter, max_diameter)
+    in_bounds = (
+        (yy >= 0)
+        & (yy < heatmap_height)
+        & (xx >= 0)
+        & (xx < heatmap_width)
+        & valid_masks.view(batch_size, max_num_bboxes, 1, 1)
+    )
+
+    # Set invalid heatmap positions to zero
+    updated_batch_gaussian_2d = torch.where(
+        in_bounds, batch_gaussians_2d, torch.zeros_like(batch_gaussians_2d)
+    )
+
+    # Labels for each box, shape (B, N, 1, 1)
+    labels = gt_bboxes_labels.view(batch_size, max_num_bboxes, 1, 1)
+    # clamp invalid labels (e.g. -1 padding) so indexing stays legal;
+    clamp_labels = labels.clamp(min=0, max=num_classes - 1)
+
+    # (B, max_num_bboxes, 1, 1) + (B, max_num_bboxes, max_diameter, max_diameter) -> (B, max_num_bboxes, max_diameter, max_diameter)
+    flat_idx = (
+        clamp_labels * heatmap_height * heatmap_width
+        + yy.clamp(0, heatmap_height - 1) * heatmap_width
+        + xx.clamp(0, heatmap_width - 1)
+    )
+
+    # For the same pixel, it keeps the maximum value across all bboxes in the same batch,
+    # so it uses scatter_reduce with "amax"
+    # For invalid bboxes, they will not contribute to the heatmap since their valid_masks are False,
+    # and thus their updated_batch_gaussian_2d values are zero.
+    heatmaps.view(batch_size, -1).scatter_reduce_(
+        dim=1,
+        index=flat_idx.view(batch_size, -1),
+        src=updated_batch_gaussian_2d.view(batch_size, -1),
+        reduce="amax",
+        include_self=True,
+    )
+    return heatmaps
 
 
 def gaussian_radius(box_size: tuple[float, float], min_overlap: float = 0.1) -> int:

--- a/autoware_ml/models/detection3d/task_modules/tests/test_heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/tests/test_heatmap.py
@@ -403,7 +403,6 @@ class TestBatchCircleNMS(unittest.TestCase):
     ) -> tuple[
         Float32[torch.Tensor, "batch_size num_classes max_num_bboxes 2"],
         Float32[torch.Tensor, "batch_size num_classes max_num_bboxes"],
-        Bool[torch.Tensor, "batch_size num_classes max_num_bboxes"],
         Float32[torch.Tensor, "batch_size num_classes max_num_bboxes"],
     ]:
         """
@@ -426,13 +425,6 @@ class TestBatchCircleNMS(unittest.TestCase):
             .expand(shape)
             .contiguous()
         )
-        # Rows are class-wise, matching the class_ids layout decode_outputs builds
-        bboxes_labels = (
-            torch.arange(self.num_classes, dtype=torch.int64, device=self.device)
-            .view(1, self.num_classes, 1)
-            .expand(shape)
-            .contiguous()
-        )
         valid_bboxes_masks = (
             torch.tensor(
                 valid_masks if valid_masks is not None else [True] * max_num_bboxes,
@@ -443,7 +435,7 @@ class TestBatchCircleNMS(unittest.TestCase):
             .expand(shape)
             .contiguous()
         )
-        return (bboxes_centers, bboxes_scores, bboxes_labels, valid_bboxes_masks)
+        return (bboxes_centers, bboxes_scores, valid_bboxes_masks)
 
     def _expected_keep_masks(
         self, keep_masks_row: Sequence[bool]
@@ -459,7 +451,7 @@ class TestBatchCircleNMS(unittest.TestCase):
     def test_batch_circle_nms_suppresses_neighbours_within_radius(self) -> None:
         """Test that a lower scoring box within min_radius of a kept box is suppressed."""
         # Two tight pairs 5 m apart: the second box of each pair falls inside min_radius
-        centers, scores, labels, valid_masks = self._build_inputs(
+        centers, scores, valid_masks = self._build_inputs(
             centers=[[0.0, 0.0], [0.5, 0.0], [5.0, 0.0], [5.4, 0.0]],
             scores=[0.9, 0.8, 0.7, 0.6],
         )
@@ -467,7 +459,6 @@ class TestBatchCircleNMS(unittest.TestCase):
         keep_masks = batch_circle_nms(
             bboxes_centers=centers,
             scores=scores,
-            bboxes_labels=labels,
             min_radius=self.min_radius,
             valid_bboxes_masks=valid_masks,
             post_max_size=self.post_max_size,
@@ -484,7 +475,7 @@ class TestBatchCircleNMS(unittest.TestCase):
         Because B is already gone it cannot suppress anything, so C survives.
         """
         # Collinear boxes 1.5 m apart with min_radius 2.0: A-B and B-C overlap, A-C does not
-        centers, scores, labels, valid_masks = self._build_inputs(
+        centers, scores, valid_masks = self._build_inputs(
             centers=[[0.0, 0.0], [1.5, 0.0], [3.0, 0.0]],
             scores=[0.9, 0.8, 0.7],
         )
@@ -492,7 +483,6 @@ class TestBatchCircleNMS(unittest.TestCase):
         keep_masks = batch_circle_nms(
             bboxes_centers=centers,
             scores=scores,
-            bboxes_labels=labels,
             min_radius=2.0,
             valid_bboxes_masks=valid_masks,
             post_max_size=self.post_max_size,
@@ -508,7 +498,7 @@ class TestBatchCircleNMS(unittest.TestCase):
         Test that an invalid box is dropped and does not suppress its neighbour, so the
         neighbour survives even though it sits inside the invalid box's radius.
         """
-        centers, scores, labels, valid_masks = self._build_inputs(
+        centers, scores, valid_masks = self._build_inputs(
             centers=[[0.0, 0.0], [0.5, 0.0], [5.0, 0.0]],
             scores=[0.9, 0.8, 0.7],
             # The highest scoring box is invalid
@@ -518,7 +508,6 @@ class TestBatchCircleNMS(unittest.TestCase):
         keep_masks = batch_circle_nms(
             bboxes_centers=centers,
             scores=scores,
-            bboxes_labels=labels,
             min_radius=self.min_radius,
             valid_bboxes_masks=valid_masks,
             post_max_size=self.post_max_size,
@@ -533,7 +522,7 @@ class TestBatchCircleNMS(unittest.TestCase):
         Test that post_max_size truncates a class row to its highest scoring survivors even when
         no box overlaps another.
         """
-        centers, scores, labels, valid_masks = self._build_inputs(
+        centers, scores, valid_masks = self._build_inputs(
             centers=[[0.0, 0.0], [10.0, 0.0], [20.0, 0.0], [30.0, 0.0]],
             scores=[0.6, 0.9, 0.7, 0.8],
         )
@@ -541,7 +530,6 @@ class TestBatchCircleNMS(unittest.TestCase):
         keep_masks = batch_circle_nms(
             bboxes_centers=centers,
             scores=scores,
-            bboxes_labels=labels,
             min_radius=self.min_radius,
             valid_bboxes_masks=valid_masks,
             post_max_size=2,
@@ -559,7 +547,7 @@ class TestBatchCircleNMS(unittest.TestCase):
         """
         # Every class row of every sample holds the same two overlapping centers, so a box that
         # is suppressed anywhere other than inside its own row would show up as a missing keep
-        centers, scores, labels, valid_masks = self._build_inputs(
+        centers, scores, valid_masks = self._build_inputs(
             centers=[[0.0, 0.0], [0.2, 0.0]],
             scores=[0.9, 0.8],
         )
@@ -567,7 +555,6 @@ class TestBatchCircleNMS(unittest.TestCase):
         keep_masks = batch_circle_nms(
             bboxes_centers=centers,
             scores=scores,
-            bboxes_labels=labels,
             min_radius=self.min_radius,
             valid_bboxes_masks=valid_masks,
             post_max_size=self.post_max_size,
@@ -577,38 +564,6 @@ class TestBatchCircleNMS(unittest.TestCase):
         expected_keep_masks = self._expected_keep_masks([True, False])
         self.assertTrue(torch.equal(keep_masks, expected_keep_masks))
         self.assertEqual(int(keep_masks.sum().item()), self.batch_size * self.num_classes)
-
-    def test_batch_circle_nms_only_suppresses_boxes_sharing_a_label(self) -> None:
-        """
-        Test that overlapping boxes inside the same class row survive when their labels differ,
-        which is the only situation where the label check changes the outcome.
-        """
-        # Three overlapping centers per row, with the middle box carrying a different label
-        centers, scores, _, valid_masks = self._build_inputs(
-            centers=[[0.0, 0.0], [0.2, 0.0], [0.4, 0.0]],
-            scores=[0.9, 0.8, 0.7],
-        )
-        # Override the class-wise labels so a single row carries more than one label
-        bboxes_labels = (
-            torch.tensor([0, 1, 0], dtype=torch.int64, device=self.device)
-            .view(1, 1, 3)
-            .expand(self.batch_size, self.num_classes, 3)
-            .contiguous()
-        )
-
-        keep_masks = batch_circle_nms(
-            bboxes_centers=centers,
-            scores=scores,
-            bboxes_labels=bboxes_labels,
-            min_radius=self.min_radius,
-            valid_bboxes_masks=valid_masks,
-            post_max_size=self.post_max_size,
-        )
-
-        # Box 1 differs in label so it survives; box 2 shares label 0 with box 0 and is dropped
-        # because they overlap
-        expected_keep_masks = self._expected_keep_masks([True, True, False])
-        self.assertTrue(torch.equal(keep_masks, expected_keep_masks))
 
 
 if __name__ == "__main__":

--- a/autoware_ml/models/detection3d/task_modules/tests/test_heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/tests/test_heatmap.py
@@ -431,6 +431,71 @@ class TestCreateGaussianHeatmap(unittest.TestCase):
         )
         self.assertTrue(torch.all(gaussian_heatmaps == 0.0))
 
+    def test_create_gaussian_heatmaps_rejects_labels_beyond_num_classes(self) -> None:
+        """Test that a label outside [0, num_classes - 1] is rejected instead of silently clamped."""
+        # ``num_classes`` is the first out-of-range index; clamping it would splat the box onto
+        # the last class channel and corrupt that class's supervision without any warning.
+        for out_of_range_label in (self.num_classes, self.num_classes + 7):
+            with self.subTest(label=out_of_range_label):
+                gt_bboxes_labels = self.gt_bboxes_labels.clone()
+                gt_bboxes_labels[1, 0] = out_of_range_label
+
+                with self.assertRaisesRegex(ValueError, "label"):
+                    create_gaussian_heatmaps(
+                        heatmap_width=self.heatmap_width,
+                        heatmap_height=self.heatmap_height,
+                        num_classes=self.num_classes,
+                        centers=self.centers,
+                        gaussian_radii=self.gaussian_radii,
+                        gt_bboxes_labels=gt_bboxes_labels,
+                        valid_masks=torch.ones_like(gt_bboxes_labels, dtype=torch.bool),
+                        device=self.device,
+                    )
+
+    def test_create_gaussian_heatmaps_rejects_out_of_range_label_on_invalid_box(self) -> None:
+        """Test that the label range check covers padded boxes, not just the valid ones."""
+        # The check runs before ``valid_masks`` is applied, so padding must use a sentinel the
+        # clamp handles (such as -1) rather than an above-range one.
+        gt_bboxes_labels = self.gt_bboxes_labels.clone()
+        gt_bboxes_labels[0, 1] = self.num_classes
+        valid_masks = torch.tensor([[1, 0, 1], [1, 1, 1]], device=self.device, dtype=torch.bool)
+
+        with self.assertRaisesRegex(ValueError, "label"):
+            create_gaussian_heatmaps(
+                heatmap_width=self.heatmap_width,
+                heatmap_height=self.heatmap_height,
+                num_classes=self.num_classes,
+                centers=self.centers,
+                gaussian_radii=self.gaussian_radii,
+                gt_bboxes_labels=gt_bboxes_labels,
+                valid_masks=valid_masks,
+                device=self.device,
+            )
+
+    def test_create_gaussian_heatmaps_accepts_last_class_label(self) -> None:
+        """Test that ``num_classes - 1`` is still accepted, pinning the check to ``>=``."""
+        last_class = self.num_classes - 1
+        gt_bboxes_labels = self.gt_bboxes_labels.clone()
+        gt_bboxes_labels[1, 0] = last_class
+
+        gaussian_heatmaps = create_gaussian_heatmaps(
+            heatmap_width=self.heatmap_width,
+            heatmap_height=self.heatmap_height,
+            num_classes=self.num_classes,
+            centers=self.centers,
+            gaussian_radii=self.gaussian_radii,
+            gt_bboxes_labels=gt_bboxes_labels,
+            valid_masks=torch.ones_like(gt_bboxes_labels, dtype=torch.bool),
+            device=self.device,
+        )
+
+        self.assertEqual(
+            gaussian_heatmaps.shape,
+            (self.batch_size, self.num_classes, self.heatmap_height, self.heatmap_width),
+        )
+        # The relocated box is the only contributor to the last channel, so it must be drawn there.
+        self.assertTrue(torch.any(gaussian_heatmaps[1, last_class] > 0.0))
+
 
 class TestBatchCircleNMS(unittest.TestCase):
     """Unit tests for the batch_circle_nms function."""

--- a/autoware_ml/models/detection3d/task_modules/tests/test_heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/tests/test_heatmap.py
@@ -65,14 +65,16 @@ class TestVectorizeGaussian2D(unittest.TestCase):
         self.expected = torch.zeros(2, 3, 5, 5, device=self.device, dtype=torch.float32)
 
         # batch 0, box 0: 1x1
-        self.expected[0, 0, :1, :1] = torch.tensor([[1.0]])
+        self.expected[0, 0, :1, :1] = torch.tensor([[1.0]], device=self.device, dtype=torch.float32)
 
         # batch 0, box 1: 2x2
         self.expected[0, 1, :2, :2] = torch.tensor(
             [
                 [0.0019, 0.0019],
                 [0.0019, 0.0019],
-            ]
+            ],
+            device=self.device,
+            dtype=torch.float32,
         )
 
         # batch 0, box 2: 4x4
@@ -82,7 +84,9 @@ class TestVectorizeGaussian2D(unittest.TestCase):
                 [9.2925e-07, 6.2177e-02, 6.2177e-02, 9.2925e-07],
                 [9.2925e-07, 6.2177e-02, 6.2177e-02, 9.2925e-07],
                 [0.0000e00, 9.2925e-07, 9.2925e-07, 0.0000e00],
-            ]
+            ],
+            device=self.device,
+            dtype=torch.float32,
         )
 
         # batch 1, box 0: 3x3
@@ -91,7 +95,9 @@ class TestVectorizeGaussian2D(unittest.TestCase):
                 [1.4945e-05, 3.8659e-03, 1.4945e-05],
                 [3.8659e-03, 1.0000e00, 3.8659e-03],
                 [1.4945e-05, 3.8659e-03, 1.4945e-05],
-            ]
+            ],
+            device=self.device,
+            dtype=torch.float32,
         )
 
         # batch 1, box 1: 4x4
@@ -101,7 +107,9 @@ class TestVectorizeGaussian2D(unittest.TestCase):
                 [4.0465e-04, 2.0961e-01, 2.0961e-01, 4.0465e-04],
                 [4.0465e-04, 2.0961e-01, 2.0961e-01, 4.0465e-04],
                 [7.8115e-07, 4.0465e-04, 4.0465e-04, 7.8115e-07],
-            ]
+            ],
+            device=self.device,
+            dtype=torch.float32,
         )
 
         # batch 1, box 2: 5x5
@@ -112,7 +120,9 @@ class TestVectorizeGaussian2D(unittest.TestCase):
                 [0.0, 3.7267e-06, 1.0000e00, 3.7267e-06, 0.0],
                 [0.0, 0.0, 3.7267e-06, 0.0, 0.0],
                 [0.0, 0.0, 0.0, 0.0, 0.0],
-            ]
+            ],
+            device=self.device,
+            dtype=torch.float32,
         )
 
     def test_vectorize_gaussian2d(self) -> None:

--- a/autoware_ml/models/detection3d/task_modules/tests/test_heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/tests/test_heatmap.py
@@ -1,0 +1,605 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for heatmap utilities."""
+
+import unittest
+from typing import Sequence
+
+from jaxtyping import Float32, Bool
+import torch
+
+from autoware_ml.models.detection3d.task_modules.heatmap import (
+    _vectorize_gaussian2d,
+    vectorize_gaussian_radii,
+    create_gaussian_heatmaps,
+    batch_circle_nms,
+)
+
+
+class TestVectorizeGaussianRadii(unittest.TestCase):
+    """Unit tests for the vectorize_gaussian_radii function."""
+
+    def setUp(self) -> None:
+        """Set up the same input tensors for all tests."""
+        # (batch_size, 3)
+        self.widths = torch.tensor([[1.0, 2.0, 3.2], [3.0, 4.4, 2.8]])
+        self.heights = torch.tensor([[1.0, 2.0, 3.2], [3.0, 4.8, 5.0]])
+        self.min_overlap = 0.1
+
+    def test_vectorize_gaussian_radii(self) -> None:
+        """Test the vectorize_gaussian_radii function."""
+        gaussian_radii = vectorize_gaussian_radii(
+            widths=self.widths,
+            heights=self.heights,
+            min_overlap=self.min_overlap,
+        )
+
+        self.assertEqual(gaussian_radii.shape, self.widths.shape)
+        expected_radii = torch.tensor([[0, 0, 1], [1, 1, 1]], dtype=torch.int32)
+        self.assertTrue(torch.allclose(gaussian_radii, expected_radii))
+
+
+class TestVectorizeGaussian2D(unittest.TestCase):
+    """Unit tests for the _vectorize_gaussian2d function."""
+
+    def setUp(self) -> None:
+        """Set up the same input tensors for all tests."""
+        self.device = torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")
+        # (batch_size, 3)
+        self.widths = torch.tensor([[1, 2, 4], [3, 4, 5]], device=self.device, dtype=torch.int32)
+        self.heights = torch.tensor([[1, 2, 4], [3, 4, 5]], device=self.device, dtype=torch.int32)
+        self.min_overlap = 0.1
+        # (batch_size, max_num_boxes, max_height, max_width)
+        self.expected = torch.zeros(2, 3, 5, 5, device=self.device, dtype=torch.float32)
+
+        # batch 0, box 0: 1x1
+        self.expected[0, 0, :1, :1] = torch.tensor([[1.0]])
+
+        # batch 0, box 1: 2x2
+        self.expected[0, 1, :2, :2] = torch.tensor(
+            [
+                [0.0019, 0.0019],
+                [0.0019, 0.0019],
+            ]
+        )
+
+        # batch 0, box 2: 4x4
+        self.expected[0, 2, :4, :4] = torch.tensor(
+            [
+                [0.0000e00, 9.2925e-07, 9.2925e-07, 0.0000e00],
+                [9.2925e-07, 6.2177e-02, 6.2177e-02, 9.2925e-07],
+                [9.2925e-07, 6.2177e-02, 6.2177e-02, 9.2925e-07],
+                [0.0000e00, 9.2925e-07, 9.2925e-07, 0.0000e00],
+            ]
+        )
+
+        # batch 1, box 0: 3x3
+        self.expected[1, 0, :3, :3] = torch.tensor(
+            [
+                [1.4945e-05, 3.8659e-03, 1.4945e-05],
+                [3.8659e-03, 1.0000e00, 3.8659e-03],
+                [1.4945e-05, 3.8659e-03, 1.4945e-05],
+            ]
+        )
+
+        # batch 1, box 1: 4x4
+        self.expected[1, 1, :4, :4] = torch.tensor(
+            [
+                [7.8115e-07, 4.0465e-04, 4.0465e-04, 7.8115e-07],
+                [4.0465e-04, 2.0961e-01, 2.0961e-01, 4.0465e-04],
+                [4.0465e-04, 2.0961e-01, 2.0961e-01, 4.0465e-04],
+                [7.8115e-07, 4.0465e-04, 4.0465e-04, 7.8115e-07],
+            ]
+        )
+
+        # batch 1, box 2: 5x5
+        self.expected[1, 2] = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 3.7267e-06, 0.0, 0.0],
+                [0.0, 3.7267e-06, 1.0000e00, 3.7267e-06, 0.0],
+                [0.0, 0.0, 3.7267e-06, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        )
+
+    def test_vectorize_gaussian2d(self) -> None:
+        """Test the _vectorize_gaussian2d function with 5x5 output but different sigma for each inputs."""
+        gaussian_2d = _vectorize_gaussian2d(
+            heights=self.heights,
+            widths=self.widths,
+            sigmas=torch.tensor(
+                [[0.1, 0.2, 0.3], [0.3, 0.4, 0.2]], device=self.device, dtype=torch.float32
+            ),  # Example sigmas
+            valid_masks=torch.tensor([[1, 1, 1], [1, 1, 1]], device=self.device, dtype=torch.bool),
+            device=self.device,
+            dtype=torch.float32,
+        )
+
+        self.assertTrue(torch.allclose(gaussian_2d, self.expected, atol=1e-4))
+        self.assertEqual(gaussian_2d.shape[:2], self.widths.shape)
+
+    def test_vectorize_gaussian2d_invalid_mask(self) -> None:
+        """Test the _vectorize_gaussian2d function with 5x5 output but the last box is invalid."""
+        gaussian_2d = _vectorize_gaussian2d(
+            heights=self.heights,
+            widths=self.widths,
+            sigmas=torch.tensor(
+                [[0.1, 0.2, 0.3], [0.3, 0.4, 0.2]], device=self.device, dtype=torch.float32
+            ),  # Example sigmas
+            valid_masks=torch.tensor([[1, 1, 1], [1, 1, 0]], device=self.device, dtype=torch.bool),
+            device=self.device,
+            dtype=torch.float32,
+        )
+
+        # batch 1, box 2: 5x5
+        # Set to zeros since valid_masks indicates this box is invalid
+        self.expected[1, 2] = torch.zeros((5, 5), device=self.device, dtype=torch.float32)
+        self.assertTrue(torch.allclose(gaussian_2d, self.expected, atol=1e-4))
+        self.assertEqual(gaussian_2d.shape[:2], self.widths.shape)
+
+
+class TestCreateGaussianHeatmap(unittest.TestCase):
+    """Unit tests for the create_gaussian_heatmap function."""
+
+    def setUp(self) -> None:
+        """Set up the same input tensors for all tests."""
+        self.device = torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")
+        self.heatmap_width = 8
+        self.heatmap_height = 8
+        self.num_classes = 5
+        self.batch_size = 2
+        self.gt_bboxes_labels = torch.tensor(
+            [[0, 0, 2], [1, 2, 2]], device=self.device, dtype=torch.int64
+        )
+        # (batch_size, 3, 2)
+        self.centers = torch.tensor(
+            [[[1, 2], [3, 4], [5, 6]], [[2, 3], [4, 5], [6, 7]]],
+            device=self.device,
+            dtype=torch.int64,
+        )
+        self.gaussian_radii = torch.tensor(
+            [[1, 2, 1], [4, 1, 3]], device=self.device, dtype=torch.int32
+        )
+        self.expected_heatmap = torch.zeros(
+            self.batch_size,
+            self.num_classes,
+            self.heatmap_height,
+            self.heatmap_width,
+            device=self.device,
+            dtype=torch.float32,
+        )
+
+        # Manually draw the expected heatmaps for each valid box in the batch
+        # Batch 0, Class 0, center (1, 2) and radius 1, center (3, 4) and radius 2
+        self.expected_heatmap[0, 0] = torch.tensor(
+            [
+                [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000],
+                [0.0183, 0.1353, 0.0183, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000],
+                [0.1353, 1.0000, 0.1353, 0.0561, 0.0273, 0.0032, 0.0000, 0.0000],
+                [0.0183, 0.1353, 0.2369, 0.4868, 0.2369, 0.0273, 0.0000, 0.0000],
+                [0.0000, 0.0561, 0.4868, 1.0000, 0.4868, 0.0561, 0.0000, 0.0000],
+                [0.0000, 0.0273, 0.2369, 0.4868, 0.2369, 0.0273, 0.0000, 0.0000],
+                [0.0000, 0.0032, 0.0273, 0.0561, 0.0273, 0.0032, 0.0000, 0.0000],
+                [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000],
+            ],
+            dtype=torch.float32,
+            device=self.device,
+        )
+
+        # Batch 0, Class 2, center (5, 6) and radius 1
+        self.expected_heatmap[0, 2, 5:8, :] = torch.tensor(
+            [
+                [0.0000, 0.0000, 0.0000, 0.0000, 0.0183, 0.1353, 0.0183, 0.0000],
+                [0.0000, 0.0000, 0.0000, 0.0000, 0.1353, 1.0000, 0.1353, 0.0000],
+                [0.0000, 0.0000, 0.0000, 0.0000, 0.0183, 0.1353, 0.0183, 0.0000],
+            ],
+            dtype=torch.float32,
+            device=self.device,
+        )
+
+        # Batch 1, Class 1, center (2, 3) and radius 4
+        self.expected_heatmap[1, 1] = torch.tensor(
+            [
+                [
+                    5.5638e-02,
+                    1.0837e-01,
+                    1.3534e-01,
+                    1.0837e-01,
+                    5.5638e-02,
+                    1.8316e-02,
+                    3.8659e-03,
+                    0.0000,
+                ],
+                [
+                    1.6901e-01,
+                    3.2919e-01,
+                    4.1111e-01,
+                    3.2919e-01,
+                    1.6901e-01,
+                    5.5638e-02,
+                    1.1744e-02,
+                    0.0000,
+                ],
+                [
+                    3.2919e-01,
+                    6.4118e-01,
+                    8.0074e-01,
+                    6.4118e-01,
+                    3.2919e-01,
+                    1.0837e-01,
+                    2.2873e-02,
+                    0.0000,
+                ],
+                [
+                    4.1111e-01,
+                    8.0074e-01,
+                    1.0000e00,
+                    8.0074e-01,
+                    4.1111e-01,
+                    1.3534e-01,
+                    2.8566e-02,
+                    0.0000,
+                ],
+                [
+                    3.2919e-01,
+                    6.4118e-01,
+                    8.0074e-01,
+                    6.4118e-01,
+                    3.2919e-01,
+                    1.0837e-01,
+                    2.2873e-02,
+                    0.0000,
+                ],
+                [
+                    1.6901e-01,
+                    3.2919e-01,
+                    4.1111e-01,
+                    3.2919e-01,
+                    1.6901e-01,
+                    5.5638e-02,
+                    1.1744e-02,
+                    0.0000,
+                ],
+                [
+                    5.5638e-02,
+                    1.0837e-01,
+                    1.3534e-01,
+                    1.0837e-01,
+                    5.5638e-02,
+                    1.8316e-02,
+                    3.8659e-03,
+                    0.0000,
+                ],
+                [
+                    1.1744e-02,
+                    2.2873e-02,
+                    2.8566e-02,
+                    2.2873e-02,
+                    1.1744e-02,
+                    3.8659e-03,
+                    8.1599e-04,
+                    0.0000,
+                ],
+            ],
+            dtype=torch.float32,
+            device=self.device,
+        )
+
+        # Batch 1, Class 2, center (4, 5) and radius 1, center (6, 7) and radius 3
+        self.expected_heatmap[1, 2, 4:8, 3:8] = torch.tensor(
+            [
+                [0.0183, 0.1353, 0.0254, 0.0367, 0.0254],
+                [0.1353, 1.0000, 0.1593, 0.2301, 0.1593],
+                [0.0254, 0.1593, 0.4797, 0.6926, 0.4797],
+                [0.0367, 0.2301, 0.6926, 1.0000, 0.6926],
+            ],
+            dtype=torch.float32,
+            device=self.device,
+        )
+
+    def test_create_gaussian_heatmaps(self) -> None:
+        """Test create_gaussian_heatmap function with 8x8 output but different sigma for each inputs."""
+        gaussian_heatmaps = create_gaussian_heatmaps(
+            heatmap_width=self.heatmap_width,
+            heatmap_height=self.heatmap_height,
+            num_classes=self.num_classes,
+            centers=self.centers,
+            gaussian_radii=self.gaussian_radii,
+            gt_bboxes_labels=self.gt_bboxes_labels,
+            valid_masks=torch.tensor([[1, 1, 1], [1, 1, 1]], device=self.device, dtype=torch.bool),
+            batch_size=self.batch_size,
+            device=self.device,
+        )
+
+        self.assertEqual(
+            gaussian_heatmaps.shape,
+            (self.batch_size, self.num_classes, self.heatmap_height, self.heatmap_width),
+        )
+        self.assertTrue(torch.allclose(gaussian_heatmaps, self.expected_heatmap, atol=1e-4))
+
+    def test_create_gaussian_heatmaps_with_invalid_mask(self) -> None:
+        """Test create_gaussian_heatmap function with 8x8 output with invalid bboxes."""
+        gaussian_heatmaps = create_gaussian_heatmaps(
+            heatmap_width=self.heatmap_width,
+            heatmap_height=self.heatmap_height,
+            num_classes=self.num_classes,
+            centers=self.centers,
+            gaussian_radii=self.gaussian_radii,
+            gt_bboxes_labels=self.gt_bboxes_labels,
+            valid_masks=torch.tensor([[1, 0, 1], [0, 1, 1]], device=self.device, dtype=torch.bool),
+            batch_size=self.batch_size,
+            device=self.device,
+        )
+
+        self.assertEqual(
+            gaussian_heatmaps.shape,
+            (self.batch_size, self.num_classes, self.heatmap_height, self.heatmap_width),
+        )
+        # For batch 1, the first box is invalid, so the heatmap for class 1 should be all zeros
+        self.expected_heatmap[1, 1] = torch.zeros(
+            (self.heatmap_height, self.heatmap_width), device=self.device, dtype=torch.float32
+        )
+        # For batch 0, the second box is invalid, so the heatmap for class 0 should only have
+        # the first box's contribution, where 1.0 from the second box (center at 3, 4) is removed
+        self.expected_heatmap[
+            0,
+            0,
+        ] = torch.tensor(
+            [
+                [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000],
+                [0.0183, 0.1353, 0.0183, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000],
+                [0.1353, 1.0000, 0.1353, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000],
+                [0.0183, 0.1353, 0.0183, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000],
+                [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000],
+                [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000],
+                [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000],
+                [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000],
+            ],
+            dtype=torch.float32,
+            device=self.device,
+        )
+        self.assertTrue(torch.allclose(gaussian_heatmaps, self.expected_heatmap, atol=1e-4))
+
+
+class TestBatchCircleNMS(unittest.TestCase):
+    """Unit tests for the batch_circle_nms function."""
+
+    def setUp(self) -> None:
+        """Set up the common device, batch shape and NMS parameters for all tests."""
+        self.device = torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")
+        self.batch_size = 2
+        self.num_classes = 3
+        self.min_radius = 1.0
+        self.post_max_size = 10
+
+    def _build_inputs(
+        self,
+        centers: Sequence[Sequence[float]],
+        scores: Sequence[float],
+        valid_masks: Sequence[bool] | None = None,
+    ) -> tuple[
+        Float32[torch.Tensor, "batch_size num_classes max_num_bboxes 2"],
+        Float32[torch.Tensor, "batch_size num_classes max_num_bboxes"],
+        Bool[torch.Tensor, "batch_size num_classes max_num_bboxes"],
+        Float32[torch.Tensor, "batch_size num_classes max_num_bboxes"],
+    ]:
+        """
+        Repeat one row of centers and scores across every sample and class, so each test spells
+        out a single scenario while still exercising the full
+        (batch_size, num_classes, max_num_bboxes) layout. Placing identical geometry in every row
+        also means suppression leaking across rows would remove boxes that must survive.
+        """
+        max_num_bboxes = len(scores)
+        shape = (self.batch_size, self.num_classes, max_num_bboxes)
+        bboxes_centers = (
+            torch.tensor(centers, dtype=torch.float32, device=self.device)
+            .view(1, 1, max_num_bboxes, 2)
+            .expand(*shape, 2)
+            .contiguous()
+        )
+        bboxes_scores = (
+            torch.tensor(scores, dtype=torch.float32, device=self.device)
+            .view(1, 1, max_num_bboxes)
+            .expand(shape)
+            .contiguous()
+        )
+        # Rows are class-wise, matching the class_ids layout decode_outputs builds
+        bboxes_labels = (
+            torch.arange(self.num_classes, dtype=torch.int64, device=self.device)
+            .view(1, self.num_classes, 1)
+            .expand(shape)
+            .contiguous()
+        )
+        valid_bboxes_masks = (
+            torch.tensor(
+                valid_masks if valid_masks is not None else [True] * max_num_bboxes,
+                dtype=torch.bool,
+                device=self.device,
+            )
+            .view(1, 1, max_num_bboxes)
+            .expand(shape)
+            .contiguous()
+        )
+        return (bboxes_centers, bboxes_scores, bboxes_labels, valid_bboxes_masks)
+
+    def _expected_keep_masks(
+        self, keep_masks_row: Sequence[bool]
+    ) -> Bool[torch.Tensor, "batch_size num_classes max_num_bboxes"]:
+        """Repeat one row of expected results across every sample and class."""
+        return (
+            torch.tensor(keep_masks_row, dtype=torch.bool, device=self.device)
+            .view(1, 1, len(keep_masks_row))
+            .expand(self.batch_size, self.num_classes, len(keep_masks_row))
+            .contiguous()
+        )
+
+    def test_batch_circle_nms_suppresses_neighbours_within_radius(self) -> None:
+        """Test that a lower scoring box within min_radius of a kept box is suppressed."""
+        # Two tight pairs 5 m apart: the second box of each pair falls inside min_radius
+        centers, scores, labels, valid_masks = self._build_inputs(
+            centers=[[0.0, 0.0], [0.5, 0.0], [5.0, 0.0], [5.4, 0.0]],
+            scores=[0.9, 0.8, 0.7, 0.6],
+        )
+
+        keep_masks = batch_circle_nms(
+            bboxes_centers=centers,
+            scores=scores,
+            bboxes_labels=labels,
+            min_radius=self.min_radius,
+            valid_bboxes_masks=valid_masks,
+            post_max_size=self.post_max_size,
+        )
+
+        # Second and fourth boxes are suppressed by the first and third boxes in each
+        # batch and classes, respectively
+        expected_keep_masks = self._expected_keep_masks([True, False, True, False])
+        self.assertTrue(torch.equal(keep_masks, expected_keep_masks))
+
+    def test_batch_circle_nms_keeps_box_suppressed_only_by_a_removed_box(self) -> None:
+        """
+        Test the greedy chain A -> B -> C, where A suppresses B and B would have suppressed C.
+        Because B is already gone it cannot suppress anything, so C survives.
+        """
+        # Collinear boxes 1.5 m apart with min_radius 2.0: A-B and B-C overlap, A-C does not
+        centers, scores, labels, valid_masks = self._build_inputs(
+            centers=[[0.0, 0.0], [1.5, 0.0], [3.0, 0.0]],
+            scores=[0.9, 0.8, 0.7],
+        )
+
+        keep_masks = batch_circle_nms(
+            bboxes_centers=centers,
+            scores=scores,
+            bboxes_labels=labels,
+            min_radius=2.0,
+            valid_bboxes_masks=valid_masks,
+            post_max_size=self.post_max_size,
+        )
+
+        # The middle box is suppressed by the first box, but the last box survives because it is
+        # only suppressed by the middle box which is already gone
+        expected_keep_masks = self._expected_keep_masks([True, False, True])
+        self.assertTrue(torch.equal(keep_masks, expected_keep_masks))
+
+    def test_batch_circle_nms_invalid_boxes_neither_kept_nor_suppressing(self) -> None:
+        """
+        Test that an invalid box is dropped and does not suppress its neighbour, so the
+        neighbour survives even though it sits inside the invalid box's radius.
+        """
+        centers, scores, labels, valid_masks = self._build_inputs(
+            centers=[[0.0, 0.0], [0.5, 0.0], [5.0, 0.0]],
+            scores=[0.9, 0.8, 0.7],
+            # The highest scoring box is invalid
+            valid_masks=[False, True, True],
+        )
+
+        keep_masks = batch_circle_nms(
+            bboxes_centers=centers,
+            scores=scores,
+            bboxes_labels=labels,
+            min_radius=self.min_radius,
+            valid_bboxes_masks=valid_masks,
+            post_max_size=self.post_max_size,
+        )
+
+        # The first box is invalid and dropped, so the second box survives even though they overlap
+        expected_keep_masks = self._expected_keep_masks([False, True, True])
+        self.assertTrue(torch.equal(keep_masks, expected_keep_masks))
+
+    def test_batch_circle_nms_caps_survivors_at_post_max_size(self) -> None:
+        """
+        Test that post_max_size truncates a class row to its highest scoring survivors even when
+        no box overlaps another.
+        """
+        centers, scores, labels, valid_masks = self._build_inputs(
+            centers=[[0.0, 0.0], [10.0, 0.0], [20.0, 0.0], [30.0, 0.0]],
+            scores=[0.6, 0.9, 0.7, 0.8],
+        )
+
+        keep_masks = batch_circle_nms(
+            bboxes_centers=centers,
+            scores=scores,
+            bboxes_labels=labels,
+            min_radius=self.min_radius,
+            valid_bboxes_masks=valid_masks,
+            post_max_size=2,
+        )
+
+        # Only the 0.9 and 0.8 boxes fit under the post_max_size cap, so the 0.6 and 0.7
+        # boxes are dropped even though they do not overlap
+        expected_keep_masks = self._expected_keep_masks([False, True, False, True])
+        self.assertTrue(torch.equal(keep_masks, expected_keep_masks))
+
+    def test_batch_circle_nms_does_not_suppress_across_classes(self) -> None:
+        """
+        Test that overlapping boxes in different class rows both survive, since NMS is applied
+        per class rather than across the whole frame.
+        """
+        # Every class row of every sample holds the same two overlapping centers, so a box that
+        # is suppressed anywhere other than inside its own row would show up as a missing keep
+        centers, scores, labels, valid_masks = self._build_inputs(
+            centers=[[0.0, 0.0], [0.2, 0.0]],
+            scores=[0.9, 0.8],
+        )
+
+        keep_masks = batch_circle_nms(
+            bboxes_centers=centers,
+            scores=scores,
+            bboxes_labels=labels,
+            min_radius=self.min_radius,
+            valid_bboxes_masks=valid_masks,
+            post_max_size=self.post_max_size,
+        )
+
+        # Each row independently keeps its own top box, for all num_classes*batch_size rows
+        expected_keep_masks = self._expected_keep_masks([True, False])
+        self.assertTrue(torch.equal(keep_masks, expected_keep_masks))
+        self.assertEqual(int(keep_masks.sum().item()), self.batch_size * self.num_classes)
+
+    def test_batch_circle_nms_only_suppresses_boxes_sharing_a_label(self) -> None:
+        """
+        Test that overlapping boxes inside the same class row survive when their labels differ,
+        which is the only situation where the label check changes the outcome.
+        """
+        # Three overlapping centers per row, with the middle box carrying a different label
+        centers, scores, _, valid_masks = self._build_inputs(
+            centers=[[0.0, 0.0], [0.2, 0.0], [0.4, 0.0]],
+            scores=[0.9, 0.8, 0.7],
+        )
+        # Override the class-wise labels so a single row carries more than one label
+        bboxes_labels = (
+            torch.tensor([0, 1, 0], dtype=torch.int64, device=self.device)
+            .view(1, 1, 3)
+            .expand(self.batch_size, self.num_classes, 3)
+            .contiguous()
+        )
+
+        keep_masks = batch_circle_nms(
+            bboxes_centers=centers,
+            scores=scores,
+            bboxes_labels=bboxes_labels,
+            min_radius=self.min_radius,
+            valid_bboxes_masks=valid_masks,
+            post_max_size=self.post_max_size,
+        )
+
+        # Box 1 differs in label so it survives; box 2 shares label 0 with box 0 and is dropped
+        # because they overlap
+        expected_keep_masks = self._expected_keep_masks([True, True, False])
+        self.assertTrue(torch.equal(keep_masks, expected_keep_masks))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/autoware_ml/models/detection3d/task_modules/tests/test_heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/tests/test_heatmap.py
@@ -330,7 +330,6 @@ class TestCreateGaussianHeatmap(unittest.TestCase):
             gaussian_radii=self.gaussian_radii,
             gt_bboxes_labels=self.gt_bboxes_labels,
             valid_masks=torch.tensor([[1, 1, 1], [1, 1, 1]], device=self.device, dtype=torch.bool),
-            batch_size=self.batch_size,
             device=self.device,
         )
 
@@ -350,7 +349,6 @@ class TestCreateGaussianHeatmap(unittest.TestCase):
             gaussian_radii=self.gaussian_radii,
             gt_bboxes_labels=self.gt_bboxes_labels,
             valid_masks=torch.tensor([[1, 0, 1], [0, 1, 1]], device=self.device, dtype=torch.bool),
-            batch_size=self.batch_size,
             device=self.device,
         )
 

--- a/autoware_ml/models/detection3d/task_modules/tests/test_heatmap.py
+++ b/autoware_ml/models/detection3d/task_modules/tests/test_heatmap.py
@@ -381,6 +381,56 @@ class TestCreateGaussianHeatmap(unittest.TestCase):
         )
         self.assertTrue(torch.allclose(gaussian_heatmaps, self.expected_heatmap, atol=1e-4))
 
+    def test_create_gaussian_heatmaps_ignores_padded_radii(self) -> None:
+        """Test that radii of invalid bboxes do not change the heatmap nor the kernel size."""
+        valid_masks = torch.tensor([[1, 0, 1], [0, 1, 1]], device=self.device, dtype=torch.bool)
+        # The padded boxes carry radii far larger and smaller than any valid box, so a leaking
+        # padded radius would blow up (or collapse) the shared kernel size.
+        padded_gaussian_radii = self.gaussian_radii.clone()
+        padded_gaussian_radii[0, 1] = 100
+        padded_gaussian_radii[1, 0] = -7
+
+        gaussian_heatmaps = create_gaussian_heatmaps(
+            heatmap_width=self.heatmap_width,
+            heatmap_height=self.heatmap_height,
+            num_classes=self.num_classes,
+            centers=self.centers,
+            gaussian_radii=padded_gaussian_radii,
+            gt_bboxes_labels=self.gt_bboxes_labels,
+            valid_masks=valid_masks,
+            device=self.device,
+        )
+        expected_heatmaps = create_gaussian_heatmaps(
+            heatmap_width=self.heatmap_width,
+            heatmap_height=self.heatmap_height,
+            num_classes=self.num_classes,
+            centers=self.centers,
+            gaussian_radii=self.gaussian_radii,
+            gt_bboxes_labels=self.gt_bboxes_labels,
+            valid_masks=valid_masks,
+            device=self.device,
+        )
+        self.assertTrue(torch.allclose(gaussian_heatmaps, expected_heatmaps, atol=1e-4))
+
+    def test_create_gaussian_heatmaps_with_all_invalid_masks(self) -> None:
+        """Test that an all-invalid batch with negative padded radii yields an empty heatmap."""
+        gaussian_heatmaps = create_gaussian_heatmaps(
+            heatmap_width=self.heatmap_width,
+            heatmap_height=self.heatmap_height,
+            num_classes=self.num_classes,
+            centers=self.centers,
+            gaussian_radii=torch.full_like(self.gaussian_radii, -1),
+            gt_bboxes_labels=self.gt_bboxes_labels,
+            valid_masks=torch.zeros_like(self.gt_bboxes_labels, dtype=torch.bool),
+            device=self.device,
+        )
+
+        self.assertEqual(
+            gaussian_heatmaps.shape,
+            (self.batch_size, self.num_classes, self.heatmap_height, self.heatmap_width),
+        )
+        self.assertTrue(torch.all(gaussian_heatmaps == 0.0))
+
 
 class TestBatchCircleNMS(unittest.TestCase):
     """Unit tests for the batch_circle_nms function."""


### PR DESCRIPTION
## Summary
This PR adds the following functions to `models/detection3d/task_modules/heatmap.py` to support vectorization in heatmap and circle_nms-related functions. Specifically, it makes the following changes:

- Add `batch_circle_nms` to compute `keep_masks` for bboxes in their own batch and classes dimensions [[1]](https://github.com/tier4/autoware-ml/pull/86/changes#diff-60b678f94f962d25b56fdadb6aa707f35df21e09d9ca59360afb5d33a18e7529R15).
- Add `vectorize_gaussian_radii` to compute radius for each sample in a batch without any for-loop [[2]](https://github.com/tier4/autoware-ml/pull/86/changes#diff-60b678f94f962d25b56fdadb6aa707f35df21e09d9ca59360afb5d33a18e7529R112).  
- Add `vectorize_gaussian2d` to compute gaussian in 2D for each sample in a batch [[3]](https://github.com/tier4/autoware-ml/pull/86/changes#diff-60b678f94f962d25b56fdadb6aa707f35df21e09d9ca59360afb5d33a18e7529R150).
- Add `create_gaussian_heatmaps` to create a heatmap in `(batch_size, num_classes, height, width)` for each sample in a batch without any for-loop [[4]](https://github.com/tier4/autoware-ml/pull/86/changes#diff-60b678f94f962d25b56fdadb6aa707f35df21e09d9ca59360afb5d33a18e7529R218).
- Add unittests for the newly added functions to verify their results are the same with their for-loop versions [[5]](https://github.com/tier4/autoware-ml/pull/86/changes#diff-98a8e9c4573b1ca8bac2a67e4921438eb44bffc4207965bd7468c14fe7cfdf16R1).

<!-- Link related issues or feature requests -->

## Checklist

- [x] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [x] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

## Unit tests
- Expected results in unittests are computed from the original for-loop implementations.
```
python -m unittest autoware_ml/models/detection3d/task_modules/tests/test_heatmap.py 
..........
----------------------------------------------------------------------
Ran 10 tests in 0.277s

OK
```