### PR TITLE
feat(bevfusion): correct behaviors that deviated from the reference implementation

### DIFF
--- a/autoware_ml/configs/tasks/detection3d/bevfusion/base.yaml
+++ b/autoware_ml/configs/tasks/detection3d/bevfusion/base.yaml
@@ -192,3 +192,4 @@ data_preprocessing:
       point_cloud_range: ${point_cloud_range}
       max_num_points: 32
       max_voxels: 120000
+      eval_max_voxels: 160000

--- a/autoware_ml/configs/tasks/detection3d/bevfusion/base.yaml
+++ b/autoware_ml/configs/tasks/detection3d/bevfusion/base.yaml
@@ -16,6 +16,7 @@ datamodule:
     points: list
     gt_boxes: list
     gt_labels: list
+    gt_num_points: list
 
 model:
   _target_: autoware_ml.models.detection3d.bevfusion.BEVFusionDetectionModel

--- a/autoware_ml/configs/tasks/detection3d/bevfusion/camera_lidar_voxel0075_second_secfpn_54m_nuscenes.yaml
+++ b/autoware_ml/configs/tasks/detection3d/bevfusion/camera_lidar_voxel0075_second_secfpn_54m_nuscenes.yaml
@@ -55,6 +55,7 @@ datamodule:
         time_dim: 4
         pad_empty_sweeps: true
         remove_close: true
+        selection: random
       - _target_: autoware_ml.transforms.camera_lidar.camera_lidar.ImageAug3D
         final_dim: ${image_size}
         resize_lim: [0.38, 0.55]

--- a/autoware_ml/configs/tasks/detection3d/bevfusion/camera_lidar_voxel0075_second_secfpn_54m_nuscenes.yaml
+++ b/autoware_ml/configs/tasks/detection3d/bevfusion/camera_lidar_voxel0075_second_secfpn_54m_nuscenes.yaml
@@ -55,7 +55,7 @@ datamodule:
         time_dim: 4
         pad_empty_sweeps: true
         remove_close: true
-        selection: random
+        test_mode: false
       - _target_: autoware_ml.transforms.camera_lidar.camera_lidar.ImageAug3D
         final_dim: ${image_size}
         resize_lim: [0.38, 0.55]

--- a/autoware_ml/configs/tasks/detection3d/bevfusion/camera_lidar_voxel0170_second_secfpn_120m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/bevfusion/camera_lidar_voxel0170_second_secfpn_120m_t4dataset_j6gen2.yaml
@@ -61,6 +61,7 @@ datamodule:
         time_dim: 4
         pad_empty_sweeps: true
         remove_close: true
+        selection: random
       - _target_: autoware_ml.transforms.camera_lidar.camera_lidar.ImageAug3D
         final_dim: ${image_size}
         resize_lim: [0.29, 0.35]

--- a/autoware_ml/configs/tasks/detection3d/bevfusion/camera_lidar_voxel0170_second_secfpn_120m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/bevfusion/camera_lidar_voxel0170_second_secfpn_120m_t4dataset_j6gen2.yaml
@@ -61,7 +61,7 @@ datamodule:
         time_dim: 4
         pad_empty_sweeps: true
         remove_close: true
-        selection: random
+        test_mode: false
       - _target_: autoware_ml.transforms.camera_lidar.camera_lidar.ImageAug3D
         final_dim: ${image_size}
         resize_lim: [0.29, 0.35]

--- a/autoware_ml/configs/tasks/detection3d/bevfusion/lidar_voxel0075_second_secfpn_54m_nuscenes.yaml
+++ b/autoware_ml/configs/tasks/detection3d/bevfusion/lidar_voxel0075_second_secfpn_54m_nuscenes.yaml
@@ -44,6 +44,7 @@ datamodule:
         time_dim: 4
         pad_empty_sweeps: true
         remove_close: true
+        selection: random
       - _target_: autoware_ml.transforms.point_cloud.geometry.GlobalRotScaleTrans
         rot_range: [-0.78539816, 0.78539816]
         scale_ratio_range: [0.9, 1.1]

--- a/autoware_ml/configs/tasks/detection3d/bevfusion/lidar_voxel0075_second_secfpn_54m_nuscenes.yaml
+++ b/autoware_ml/configs/tasks/detection3d/bevfusion/lidar_voxel0075_second_secfpn_54m_nuscenes.yaml
@@ -44,7 +44,7 @@ datamodule:
         time_dim: 4
         pad_empty_sweeps: true
         remove_close: true
-        selection: random
+        test_mode: false
       - _target_: autoware_ml.transforms.point_cloud.geometry.GlobalRotScaleTrans
         rot_range: [-0.78539816, 0.78539816]
         scale_ratio_range: [0.9, 1.1]

--- a/autoware_ml/configs/tasks/detection3d/bevfusion/lidar_voxel0170_second_secfpn_120m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/bevfusion/lidar_voxel0170_second_secfpn_120m_t4dataset_j6gen2.yaml
@@ -52,6 +52,7 @@ datamodule:
         time_dim: 4
         pad_empty_sweeps: true
         remove_close: true
+        selection: random
       - _target_: autoware_ml.transforms.point_cloud.geometry.GlobalRotScaleTrans
         rot_range: [-0.78539816, 0.78539816]
         scale_ratio_range: [0.95, 1.05]
@@ -111,12 +112,14 @@ model:
     num_proposals: 500
     class_names: ${dataset.detection3d.class_names}
     num_classes: ${dataset.detection3d.num_classes}
-    dense_heatmap_pooling_classes: [car, truck, bus]
+    dense_heatmap_pooling_classes: [car, truck, bus, barrier]
+    head_hidden_channels: 64
+    norm_eps: 1.0e-5
     nms_type: circle
-    nms_min_radius: 0.25
+    nms_min_radius: 0.5
     nms_groups:
       - class_names: [car, truck, bus]
-        nms_radius: 0.25
+        nms_radius: 0.5
         post_max_size: 300
       - class_names: [bicycle]
         nms_radius: 0.0

--- a/autoware_ml/configs/tasks/detection3d/bevfusion/lidar_voxel0170_second_secfpn_120m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/bevfusion/lidar_voxel0170_second_secfpn_120m_t4dataset_j6gen2.yaml
@@ -115,6 +115,7 @@ model:
     dense_heatmap_pooling_classes: [car, truck, bus, barrier]
     head_hidden_channels: 64
     norm_eps: 1.0e-5
+    norm_momentum: 0.1
     nms_type: circle
     nms_min_radius: 0.5
     nms_groups:

--- a/autoware_ml/configs/tasks/detection3d/bevfusion/lidar_voxel0170_second_secfpn_120m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/bevfusion/lidar_voxel0170_second_secfpn_120m_t4dataset_j6gen2.yaml
@@ -52,7 +52,7 @@ datamodule:
         time_dim: 4
         pad_empty_sweeps: true
         remove_close: true
-        selection: random
+        test_mode: false
       - _target_: autoware_ml.transforms.point_cloud.geometry.GlobalRotScaleTrans
         rot_range: [-0.78539816, 0.78539816]
         scale_ratio_range: [0.95, 1.05]

--- a/autoware_ml/configs/tasks/detection3d/centerpoint/base.yaml
+++ b/autoware_ml/configs/tasks/detection3d/centerpoint/base.yaml
@@ -106,4 +106,5 @@ data_preprocessing:
       voxel_size: ${voxel_size}
       point_cloud_range: ${point_cloud_range}
       max_num_points: 32
-      max_voxels: 96000
+      max_voxels: 120000
+      eval_max_voxels: 160000

--- a/autoware_ml/configs/tasks/detection3d/centerpoint/base.yaml
+++ b/autoware_ml/configs/tasks/detection3d/centerpoint/base.yaml
@@ -13,6 +13,7 @@ datamodule:
     points: list
     gt_boxes: list
     gt_labels: list
+    gt_num_points: list
 model:
   _target_: autoware_ml.models.detection3d.centerpoint.CenterPointDetectionModel
   metrics: ${dataset.detection3d.metrics}

--- a/autoware_ml/configs/tasks/detection3d/ptv3/base.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/base.yaml
@@ -33,6 +33,7 @@ datamodule:
     grid_coord: concat
     gt_boxes: list
     gt_labels: list
+    gt_num_points: list
 
 model:
   _target_: autoware_ml.models.detection3d.ptv3.PTv3DetectionModel

--- a/autoware_ml/configs/tasks/detection3d/transfusion/base.yaml
+++ b/autoware_ml/configs/tasks/detection3d/transfusion/base.yaml
@@ -14,6 +14,7 @@ datamodule:
     points: list
     gt_boxes: list
     gt_labels: list
+    gt_num_points: list
 model:
   _target_: autoware_ml.models.detection3d.transfusion.TransFusionDetectionModel
   metrics: ${dataset.detection3d.metrics}

--- a/autoware_ml/configs/tasks/detection3d/transfusion/base.yaml
+++ b/autoware_ml/configs/tasks/detection3d/transfusion/base.yaml
@@ -147,3 +147,4 @@ data_preprocessing:
       point_cloud_range: ${point_cloud_range}
       max_num_points: 32
       max_voxels: 120000
+      eval_max_voxels: 160000

--- a/autoware_ml/datamodule/common/detection3d.py
+++ b/autoware_ml/datamodule/common/detection3d.py
@@ -76,8 +76,11 @@ def build_sweep_entries(sample: Mapping[str, Any]) -> list[dict[str, Any]]:
     """Convert stored ``lidar_sweeps`` metadata into loader-ready sweep entries.
 
     Each entry carries the sweep point-cloud path, its timestamp, and the
-    rigid transform from the sweep lidar frame into the key lidar frame,
-    composed from the stored ego poses and lidar extrinsics.
+    rigid transform from the sweep lidar frame into the key lidar frame.
+
+    The precomputed ``lidar2sensor`` matrix (the key-lidar → sweep-lidar
+    transform including ego motion) is preferred when present. Recomposing the
+    transform from the stored ego poses is only a fallback
 
     Args:
         sample: Raw sample dictionary with ``lidar_points``, ``ego2global``,
@@ -94,15 +97,21 @@ def build_sweep_entries(sample: Mapping[str, Any]) -> list[dict[str, Any]]:
     if not lidar_sweeps:
         return []
 
-    key_lidar2ego = np.asarray(sample["lidar_points"]["lidar2ego"], dtype=np.float64)
-    key_ego2global = np.asarray(sample["ego2global"], dtype=np.float64)
-    global2key_lidar = np.linalg.inv(key_ego2global @ key_lidar2ego)
+    global2key_lidar = None
 
     entries = []
     for sweep in lidar_sweeps:
-        sweep_lidar2ego = np.asarray(sweep["lidar_points"]["lidar2ego"], dtype=np.float64)
-        sweep_ego2global = np.asarray(sweep["ego2global"], dtype=np.float64)
-        sweep2key_lidar = global2key_lidar @ sweep_ego2global @ sweep_lidar2ego
+        lidar2sensor = sweep["lidar_points"].get("lidar2sensor")
+        if lidar2sensor is not None:
+            sweep2key_lidar = np.linalg.inv(np.asarray(lidar2sensor, dtype=np.float64))
+        else:
+            if global2key_lidar is None:
+                key_lidar2ego = np.asarray(sample["lidar_points"]["lidar2ego"], dtype=np.float64)
+                key_ego2global = np.asarray(sample["ego2global"], dtype=np.float64)
+                global2key_lidar = np.linalg.inv(key_ego2global @ key_lidar2ego)
+            sweep_lidar2ego = np.asarray(sweep["lidar_points"]["lidar2ego"], dtype=np.float64)
+            sweep_ego2global = np.asarray(sweep["ego2global"], dtype=np.float64)
+            sweep2key_lidar = global2key_lidar @ sweep_ego2global @ sweep_lidar2ego
         entries.append(
             {
                 "lidar_path": sweep["lidar_points"]["lidar_path"],

--- a/autoware_ml/models/base.py
+++ b/autoware_ml/models/base.py
@@ -104,6 +104,9 @@ class BaseModel(MetricEvalMixin, L.LightningModule, ABC):
             Batch dictionary after runtime preprocessing.
         """
         del dataloader_idx
+        # The preprocessing pipeline is not a registered submodule, so keep its
+        # train/eval mode in sync with the model before applying it.
+        self._data_preprocessing.train(self.training)
         return self._data_preprocessing(batch_inputs_dict)
 
     def predict_outputs(self, batch_inputs_dict: Mapping[str, Any], outputs: Any) -> Any:

--- a/autoware_ml/models/base.py
+++ b/autoware_ml/models/base.py
@@ -104,10 +104,7 @@ class BaseModel(MetricEvalMixin, L.LightningModule, ABC):
             Batch dictionary after runtime preprocessing.
         """
         del dataloader_idx
-        # The preprocessing pipeline is not a registered submodule, so keep its
-        # train/eval mode in sync with the model before applying it.
-        self._data_preprocessing.train(self.training)
-        return self._data_preprocessing(batch_inputs_dict)
+        return self._data_preprocessing(batch_inputs_dict, is_training=self.training)
 
     def predict_outputs(self, batch_inputs_dict: Mapping[str, Any], outputs: Any) -> Any:
         """Convert raw model outputs into task-level predictions.

--- a/autoware_ml/models/common/layers/conv.py
+++ b/autoware_ml/models/common/layers/conv.py
@@ -29,6 +29,7 @@ class ConvModule(nn.Module):
         out_channels: int,
         stride: int = 1,
         transpose: bool = False,
+        norm_eps: float = 1e-3,
     ) -> None:
         """Initialize the convolution block.
 
@@ -37,6 +38,7 @@ class ConvModule(nn.Module):
             out_channels: Output channel count.
             stride: Convolution stride.
             transpose: Whether to use transposed convolution.
+            norm_eps: Epsilon used by the batch normalization layer.
         """
         super().__init__()
         if transpose:
@@ -56,7 +58,7 @@ class ConvModule(nn.Module):
                 padding=1,
                 bias=False,
             )
-        self.norm = nn.BatchNorm2d(out_channels, eps=1e-3, momentum=0.01)
+        self.norm = nn.BatchNorm2d(out_channels, eps=norm_eps, momentum=0.01)
         self.activation = nn.ReLU(inplace=True)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/autoware_ml/models/common/layers/conv.py
+++ b/autoware_ml/models/common/layers/conv.py
@@ -30,6 +30,7 @@ class ConvModule(nn.Module):
         stride: int = 1,
         transpose: bool = False,
         norm_eps: float = 1e-3,
+        norm_momentum: float = 0.01,
     ) -> None:
         """Initialize the convolution block.
 
@@ -39,6 +40,7 @@ class ConvModule(nn.Module):
             stride: Convolution stride.
             transpose: Whether to use transposed convolution.
             norm_eps: Epsilon used by the batch normalization layer.
+            norm_momentum: Momentum used by the batch normalization layer.
         """
         super().__init__()
         if transpose:
@@ -58,7 +60,7 @@ class ConvModule(nn.Module):
                 padding=1,
                 bias=False,
             )
-        self.norm = nn.BatchNorm2d(out_channels, eps=norm_eps, momentum=0.01)
+        self.norm = nn.BatchNorm2d(out_channels, eps=norm_eps, momentum=norm_momentum)
         self.activation = nn.ReLU(inplace=True)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/autoware_ml/models/detection3d/heads/transfusion.py
+++ b/autoware_ml/models/detection3d/heads/transfusion.py
@@ -58,21 +58,22 @@ class LearnedPositionalEncoding(nn.Module):
         """
         super().__init__()
         self.proj = nn.Sequential(
-            nn.Linear(input_channels, embed_dims),
+            nn.Conv1d(input_channels, embed_dims, kernel_size=1),
+            nn.BatchNorm1d(embed_dims),
             nn.ReLU(inplace=True),
-            nn.Linear(embed_dims, embed_dims),
+            nn.Conv1d(embed_dims, embed_dims, kernel_size=1),
         )
 
     def forward(self, position: torch.Tensor) -> torch.Tensor:
         """Encode BEV positions into query embeddings.
 
         Args:
-            position: BEV coordinate tensor.
+            position: BEV coordinate tensor of shape ``(batch, tokens, channels)``.
 
         Returns:
-            Learned positional embeddings.
+            Learned positional embeddings of shape ``(batch, tokens, embed_dims)``.
         """
-        return self.proj(position)
+        return self.proj(position.transpose(1, 2)).transpose(1, 2)
 
 
 class TransFusionDecoderLayer(nn.Module):

--- a/autoware_ml/models/detection3d/heads/transfusion.py
+++ b/autoware_ml/models/detection3d/heads/transfusion.py
@@ -127,15 +127,26 @@ class TransFusionDecoderLayer(nn.Module):
         Returns:
             Refined query tensor.
         """
+        # TransformerDecoderLayer:
+        # The residual stream stays position-free
+        # and the positional embeddings are added to q/k/v at every attention call.
         query_tokens = query.transpose(1, 2)
         key_tokens = key.transpose(1, 2)
-        query_tokens = query_tokens + self.query_pos_encoding(query_pos)
-        key_tokens = key_tokens + self.key_pos_encoding(key_pos)
+        query_pos_embed = self.query_pos_encoding(query_pos)
+        key_pos_embed = self.key_pos_encoding(key_pos)
 
-        attended, _ = self.self_attn(query_tokens, query_tokens, query_tokens)
+        attended, _ = self.self_attn(
+            query_tokens + query_pos_embed,
+            query_tokens + query_pos_embed,
+            query_tokens + query_pos_embed,
+        )
         query_tokens = self.norm1(query_tokens + self.dropout(attended))
 
-        attended, _ = self.cross_attn(query_tokens, key_tokens, key_tokens)
+        attended, _ = self.cross_attn(
+            query_tokens + query_pos_embed,
+            key_tokens + key_pos_embed,
+            key_tokens + key_pos_embed,
+        )
         query_tokens = self.norm2(query_tokens + self.dropout(attended))
 
         ffn_output = self.ffn(query_tokens)
@@ -225,12 +236,20 @@ class SeparateHead1D(nn.Module):
     query dimension.
     """
 
-    def __init__(self, in_channels: int, heads: dict[str, tuple[int, int]]) -> None:
+    def __init__(
+        self,
+        in_channels: int,
+        heads: dict[str, tuple[int, int]],
+        hidden_channels: int,
+        norm_eps: float = 1e-3,
+    ) -> None:
         """Initialize the per-query prediction heads.
 
         Args:
             in_channels: Input feature dimension.
             heads: Mapping from head name to ``(out_channels, num_convs)``.
+            hidden_channels: Width of the intermediate branch layers.
+            norm_eps: Epsilon used by the branch batch-normalization layers.
         """
         super().__init__()
         self.heads = nn.ModuleDict()
@@ -238,10 +257,12 @@ class SeparateHead1D(nn.Module):
             layers: list[nn.Module] = []
             current_channels = in_channels
             for _ in range(max(num_convs - 1, 0)):
-                layers.append(nn.Conv1d(current_channels, in_channels, kernel_size=1, bias=False))
-                layers.append(nn.BatchNorm1d(in_channels, eps=1e-3, momentum=0.01))
+                layers.append(
+                    nn.Conv1d(current_channels, hidden_channels, kernel_size=1, bias=False)
+                )
+                layers.append(nn.BatchNorm1d(hidden_channels, eps=norm_eps, momentum=0.01))
                 layers.append(nn.ReLU(inplace=True))
-                current_channels = in_channels
+                current_channels = hidden_channels
             layers.append(nn.Conv1d(current_channels, out_channels, kernel_size=1))
             self.heads[name] = nn.Sequential(*layers)
 
@@ -323,6 +344,8 @@ class TransFusionHead(nn.Module):
         heatmap_init_bias: float = -2.19,
         nms_kernel_size: int = 3,
         use_velocity: bool = True,
+        head_hidden_channels: int | None = None,
+        norm_eps: float = 1e-3,
     ) -> None:
         """Initialize the TransFusion detection head.
 
@@ -370,6 +393,10 @@ class TransFusionHead(nn.Module):
             heatmap_init_bias: Initial bias used by the dense heatmap branch.
             nms_kernel_size: Kernel size used for local-maximum suppression.
             use_velocity: Whether the head predicts object velocity.
+            head_hidden_channels: Width of the prediction-branch hidden layers.
+                Defaults to ``hidden_channel``.
+            norm_eps: Epsilon used by the head's batch-normalization layers
+                (shared conv, heatmap head, prediction branches).
         """
         super().__init__()
         self.num_proposals = num_proposals
@@ -407,11 +434,11 @@ class TransFusionHead(nn.Module):
         self.shared_conv = nn.Conv2d(
             in_channels, hidden_channel, kernel_size=3, padding=1, bias=False
         )
-        self.shared_norm = nn.BatchNorm2d(hidden_channel, eps=1e-3, momentum=0.01)
+        self.shared_norm = nn.BatchNorm2d(hidden_channel, eps=norm_eps, momentum=0.01)
         self.shared_act = nn.ReLU(inplace=True)
 
         self.heatmap_head = nn.Sequential(
-            ConvModule(hidden_channel, hidden_channel),
+            ConvModule(hidden_channel, hidden_channel, norm_eps=norm_eps),
             nn.Conv2d(hidden_channel, num_classes, kernel_size=3, padding=1),
         )
         nn.init.constant_(self.heatmap_head[-1].bias, heatmap_init_bias)
@@ -427,8 +454,17 @@ class TransFusionHead(nn.Module):
         prediction_heads["heatmap"] = (num_classes, 2)
         if not use_velocity and "vel" in prediction_heads:
             prediction_heads.pop("vel")
+        head_hidden = head_hidden_channels if head_hidden_channels is not None else hidden_channel
         self.prediction_heads = nn.ModuleList(
-            [SeparateHead1D(hidden_channel, prediction_heads) for _ in range(num_decoder_layers)]
+            [
+                SeparateHead1D(
+                    hidden_channel,
+                    prediction_heads,
+                    hidden_channels=head_hidden,
+                    norm_eps=norm_eps,
+                )
+                for _ in range(num_decoder_layers)
+            ]
         )
 
         self.loss_heatmap = GaussianFocalLoss()

--- a/autoware_ml/models/detection3d/heads/transfusion.py
+++ b/autoware_ml/models/detection3d/heads/transfusion.py
@@ -242,6 +242,7 @@ class SeparateHead1D(nn.Module):
         heads: dict[str, tuple[int, int]],
         hidden_channels: int,
         norm_eps: float = 1e-3,
+        norm_momentum: float = 0.01,
     ) -> None:
         """Initialize the per-query prediction heads.
 
@@ -250,6 +251,7 @@ class SeparateHead1D(nn.Module):
             heads: Mapping from head name to ``(out_channels, num_convs)``.
             hidden_channels: Width of the intermediate branch layers.
             norm_eps: Epsilon used by the branch batch-normalization layers.
+            norm_momentum: Momentum used by the branch batch-normalization layers.
         """
         super().__init__()
         self.heads = nn.ModuleDict()
@@ -260,7 +262,7 @@ class SeparateHead1D(nn.Module):
                 layers.append(
                     nn.Conv1d(current_channels, hidden_channels, kernel_size=1, bias=False)
                 )
-                layers.append(nn.BatchNorm1d(hidden_channels, eps=norm_eps, momentum=0.01))
+                layers.append(nn.BatchNorm1d(hidden_channels, eps=norm_eps, momentum=norm_momentum))
                 layers.append(nn.ReLU(inplace=True))
                 current_channels = hidden_channels
             layers.append(nn.Conv1d(current_channels, out_channels, kernel_size=1))
@@ -346,6 +348,7 @@ class TransFusionHead(nn.Module):
         use_velocity: bool = True,
         head_hidden_channels: int | None = None,
         norm_eps: float = 1e-3,
+        norm_momentum: float = 0.01,
     ) -> None:
         """Initialize the TransFusion detection head.
 
@@ -397,6 +400,8 @@ class TransFusionHead(nn.Module):
                 Defaults to ``hidden_channel``.
             norm_eps: Epsilon used by the head's batch-normalization layers
                 (shared conv, heatmap head, prediction branches).
+            norm_momentum: Momentum used by the head's batch-normalization layers
+                (shared conv, heatmap head, prediction branches).
         """
         super().__init__()
         self.num_proposals = num_proposals
@@ -434,11 +439,13 @@ class TransFusionHead(nn.Module):
         self.shared_conv = nn.Conv2d(
             in_channels, hidden_channel, kernel_size=3, padding=1, bias=False
         )
-        self.shared_norm = nn.BatchNorm2d(hidden_channel, eps=norm_eps, momentum=0.01)
+        self.shared_norm = nn.BatchNorm2d(hidden_channel, eps=norm_eps, momentum=norm_momentum)
         self.shared_act = nn.ReLU(inplace=True)
 
         self.heatmap_head = nn.Sequential(
-            ConvModule(hidden_channel, hidden_channel, norm_eps=norm_eps),
+            ConvModule(
+                hidden_channel, hidden_channel, norm_eps=norm_eps, norm_momentum=norm_momentum
+            ),
             nn.Conv2d(hidden_channel, num_classes, kernel_size=3, padding=1),
         )
         nn.init.constant_(self.heatmap_head[-1].bias, heatmap_init_bias)
@@ -462,6 +469,7 @@ class TransFusionHead(nn.Module):
                     prediction_heads,
                     hidden_channels=head_hidden,
                     norm_eps=norm_eps,
+                    norm_momentum=norm_momentum,
                 )
                 for _ in range(num_decoder_layers)
             ]

--- a/autoware_ml/preprocessing/base.py
+++ b/autoware_ml/preprocessing/base.py
@@ -19,7 +19,9 @@ and model forward passes.
 """
 
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, Self
+
+import torch.nn as nn
 
 
 class DataPreprocessing:
@@ -54,6 +56,26 @@ class DataPreprocessing:
             pipeline: List of callable layers to apply sequentially.
         """
         self.pipeline = list(pipeline)
+
+    def train(self, mode: bool = True) -> Self:
+        """Propagate the train/eval mode to ``nn.Module`` pipeline layers.
+
+        The pipeline is deliberately not registered as part of the neural
+        network, so Lightning's ``model.train()``/``model.eval()`` never
+        reaches it. Layers that behave differently between training and
+        evaluation (for example a voxelizer with a larger evaluation budget)
+        rely on the owning module forwarding its mode here.
+
+        Args:
+            mode: ``True`` for training behavior, ``False`` for evaluation.
+
+        Returns:
+            This ``DataPreprocessing`` instance for chaining.
+        """
+        for layer in self.pipeline:
+            if isinstance(layer, nn.Module):
+                layer.train(mode)
+        return self
 
     def __call__(self, batch_inputs_dict: dict[str, Any]) -> dict[str, Any]:
         """Apply preprocessing layers after the batch is already on device.

--- a/autoware_ml/preprocessing/base.py
+++ b/autoware_ml/preprocessing/base.py
@@ -19,9 +19,7 @@ and model forward passes.
 """
 
 from collections.abc import Sequence
-from typing import Any, Self
-
-import torch.nn as nn
+from typing import Any
 
 
 class DataPreprocessing:
@@ -35,8 +33,9 @@ class DataPreprocessing:
     current batch dictionary and returns updates to merge into it.
 
     Args:
-        pipeline: List of callable layers to apply sequentially.
-            Each layer should accept ``dict[str, Any]`` and return ``dict[str, Any]``.
+        pipeline: List of callable layers to apply sequentially. Each layer
+            should accept ``(dict[str, Any], *, is_training: bool)`` and return
+            ``dict[str, Any]``.
 
     Example:
         ```python
@@ -57,27 +56,7 @@ class DataPreprocessing:
         """
         self.pipeline = list(pipeline)
 
-    def train(self, mode: bool = True) -> Self:
-        """Propagate the train/eval mode to ``nn.Module`` pipeline layers.
-
-        The pipeline is deliberately not registered as part of the neural
-        network, so Lightning's ``model.train()``/``model.eval()`` never
-        reaches it. Layers that behave differently between training and
-        evaluation (for example a voxelizer with a larger evaluation budget)
-        rely on the owning module forwarding its mode here.
-
-        Args:
-            mode: ``True`` for training behavior, ``False`` for evaluation.
-
-        Returns:
-            This ``DataPreprocessing`` instance for chaining.
-        """
-        for layer in self.pipeline:
-            if isinstance(layer, nn.Module):
-                layer.train(mode)
-        return self
-
-    def __call__(self, batch_inputs_dict: dict[str, Any]) -> dict[str, Any]:
+    def __call__(self, batch_inputs_dict: dict[str, Any], *, is_training: bool) -> dict[str, Any]:
         """Apply preprocessing layers after the batch is already on device.
 
         The input dictionary is mutated in place; the same object is also
@@ -87,11 +66,15 @@ class DataPreprocessing:
             batch_inputs_dict: Collated batch dictionary on the target device.
                 Mutated in place: each layer's returned mapping is merged into
                 this dict.
+            is_training: Whether the owning model is in training mode. Passed
+                to every layer so mode-dependent behavior (for example a
+                voxelizer with a larger evaluation budget) never relies on
+                implicit module state.
 
         Returns:
             The same ``batch_inputs_dict`` with preprocessing applied.
         """
         for layer in self.pipeline:
-            batch_inputs_dict |= layer(batch_inputs_dict)
+            batch_inputs_dict |= layer(batch_inputs_dict, is_training=is_training)
 
         return batch_inputs_dict

--- a/autoware_ml/preprocessing/detection3d/point_pillar.py
+++ b/autoware_ml/preprocessing/detection3d/point_pillar.py
@@ -38,7 +38,9 @@ class PointPillarPreprocessor(nn.Module):
         point_cloud_range: Spatial range ``[x_min, y_min, z_min, x_max, y_max, z_max]``
             in meters.
         max_num_points: Maximum number of points kept per pillar.
-        max_voxels: Maximum number of pillars retained per sample.
+        max_voxels: Maximum number of pillars retained per sample during training.
+        eval_max_voxels: Maximum number of pillars retained per sample during
+            evaluation and inference. Defaults to ``max_voxels`` when not given.
         voxelization_z_order_first: If ``True``, this preprocessor will transpose [x, y, z]
             coordinates to [z, y, x] in coords from voxelization.
             This is used for backward-compatible, and will be removed very soon.
@@ -56,6 +58,7 @@ class PointPillarPreprocessor(nn.Module):
         point_cloud_range: list[float],
         max_num_points: int,
         max_voxels: int,
+        eval_max_voxels: int | None = None,
         voxelization_z_order_first: bool = True,
         default_point_channels: int = 4,
     ) -> None:
@@ -66,6 +69,7 @@ class PointPillarPreprocessor(nn.Module):
         )
         self.max_num_points = max_num_points
         self.max_voxels = max_voxels
+        self.eval_max_voxels = max_voxels if eval_max_voxels is None else eval_max_voxels
         self.voxelization_z_order_first = voxelization_z_order_first
         self._default_point_channels = default_point_channels
 
@@ -119,7 +123,7 @@ class PointPillarPreprocessor(nn.Module):
             voxel_size=voxel_size,
             point_cloud_range=point_cloud_range,
             max_num_points=self.max_num_points,
-            max_voxels=self.max_voxels,
+            max_voxels=self.max_voxels if self.training else self.eval_max_voxels,
         )
 
         # Handle the case where no voxels are generated

--- a/autoware_ml/preprocessing/detection3d/point_pillar.py
+++ b/autoware_ml/preprocessing/detection3d/point_pillar.py
@@ -20,12 +20,11 @@ from typing import Any
 
 from jaxtyping import Float32
 import torch
-import torch.nn as nn
 
 from autoware_ml.ops.voxelization.voxelization import hard_voxelize
 
 
-class PointPillarPreprocessor(nn.Module):
+class PointPillarPreprocessor:
     """Convert batched point clouds into padded pillars for PointPillars models.
 
     The preprocessor voxelizes each point cloud using
@@ -40,7 +39,8 @@ class PointPillarPreprocessor(nn.Module):
         max_num_points: Maximum number of points kept per pillar.
         max_voxels: Maximum number of pillars retained per sample during training.
         eval_max_voxels: Maximum number of pillars retained per sample during
-            evaluation and inference. Defaults to ``max_voxels`` when not given.
+            evaluation and inference. Required before the preprocessor runs in
+            evaluation mode.
         voxelization_z_order_first: If ``True``, this preprocessor will transpose [x, y, z]
             coordinates to [z, y, x] in coords from voxelization.
             This is used for backward-compatible, and will be removed very soon.
@@ -62,23 +62,23 @@ class PointPillarPreprocessor(nn.Module):
         voxelization_z_order_first: bool = True,
         default_point_channels: int = 4,
     ) -> None:
-        super().__init__()
-        self.register_buffer("voxel_size", torch.tensor(voxel_size, dtype=torch.float32))
-        self.register_buffer(
-            "point_cloud_range", torch.tensor(point_cloud_range, dtype=torch.float32)
-        )
+        self.voxel_size = torch.tensor(voxel_size, dtype=torch.float32)
+        self.point_cloud_range = torch.tensor(point_cloud_range, dtype=torch.float32)
         self.max_num_points = max_num_points
         self.max_voxels = max_voxels
-        self.eval_max_voxels = max_voxels if eval_max_voxels is None else eval_max_voxels
+        self.eval_max_voxels = eval_max_voxels
         self.voxelization_z_order_first = voxelization_z_order_first
         self._default_point_channels = default_point_channels
 
-    def forward(self, batch_inputs_dict: dict[str, Any]) -> dict[str, Any]:
+    def __call__(self, batch_inputs_dict: dict[str, Any], *, is_training: bool) -> dict[str, Any]:
         """Voxelize batched point clouds and append pillar tensors.
 
         Args:
             batch_inputs_dict: Batch dictionary containing a ``"points"`` key
                 with a list of ``(N_i, C)`` point tensors.
+            is_training: Whether the owning model is in training mode. Selects
+                between the ``max_voxels`` (training) and ``eval_max_voxels``
+                (evaluation) pillar budgets.
 
         Returns:
             Updated batch dictionary with the following additional keys:
@@ -88,6 +88,12 @@ class PointPillarPreprocessor(nn.Module):
             - ``"voxel_coords"`` - pillar coordinates ``(total_pillars, 4)`` in
               ``[batch, z, y, x]`` order, ``dtype=torch.int32``.
         """
+        if not is_training and self.eval_max_voxels is None:
+            raise ValueError(
+                "PointPillarPreprocessor is running in evaluation mode but 'eval_max_voxels' "
+                "is not set. Set 'eval_max_voxels' in the data_preprocessing config (use the "
+                "same value as 'max_voxels' to keep the training-time budget)."
+            )
         points_list = batch_inputs_dict["points"]
         outputs = dict(batch_inputs_dict)
         if not points_list:
@@ -123,7 +129,7 @@ class PointPillarPreprocessor(nn.Module):
             voxel_size=voxel_size,
             point_cloud_range=point_cloud_range,
             max_num_points=self.max_num_points,
-            max_voxels=self.max_voxels if self.training else self.eval_max_voxels,
+            max_voxels=self.max_voxels if is_training else self.eval_max_voxels,
         )
 
         # Handle the case where no voxels are generated

--- a/autoware_ml/preprocessing/detection3d/tests/test_point_pillar_preprocessor.py
+++ b/autoware_ml/preprocessing/detection3d/tests/test_point_pillar_preprocessor.py
@@ -55,7 +55,7 @@ class TestPointPillarPreprocessor(unittest.TestCase):
             ]
         }
 
-        outputs = self.point_pillar_preprocessor(batch)
+        outputs = self.point_pillar_preprocessor(batch, is_training=True)
         self.assertEqual(outputs["voxels"].shape, (2, 2, 4))
         self.assertEqual(outputs["num_points"].tolist(), [2, 1])
         self.assertEqual(outputs["voxel_coords"].shape, (2, 4))
@@ -69,7 +69,7 @@ class TestPointPillarPreprocessor(unittest.TestCase):
         point = torch.tensor([[0.5, 0.5, 0.0, 1.0]], dtype=torch.float32)
         batch = {"points": [point, point, point]}
 
-        outputs = self.point_pillar_preprocessor(batch)
+        outputs = self.point_pillar_preprocessor(batch, is_training=True)
 
         self.assertEqual(outputs["voxel_coords"][:, 0].tolist(), [0, 1, 2])
 
@@ -82,7 +82,7 @@ class TestPointPillarPreprocessor(unittest.TestCase):
         empty = torch.zeros((0, 4), dtype=torch.float32)
         batch = {"points": [point, empty, point]}
 
-        outputs = self.point_pillar_preprocessor(batch)
+        outputs = self.point_pillar_preprocessor(batch, is_training=True)
 
         # Two non-empty samples  2 voxels total
         self.assertEqual(outputs["voxels"].shape[0], 2)
@@ -93,11 +93,61 @@ class TestPointPillarPreprocessor(unittest.TestCase):
         Test that the PointPillarPreprocessor returns empty pillar tensors when given an
         empty batch.
         """
-        outputs = self.point_pillar_preprocessor({"points": []})
+        outputs = self.point_pillar_preprocessor({"points": []}, is_training=True)
 
         self.assertEqual(outputs["voxels"].shape, (0, 2, 4))
         self.assertEqual(outputs["num_points"].shape, (0,))
         self.assertEqual(outputs["voxel_coords"].shape, (0, 4))
+
+    def test_eval_mode_uses_eval_max_voxels_budget(self) -> None:
+        """
+        Test that the voxel budget switches with ``is_training``: training truncates at
+        ``max_voxels`` while evaluation keeps pillars up to ``eval_max_voxels``.
+        """
+        preprocessor = PointPillarPreprocessor(
+            voxel_size=[1.0, 1.0, 4.0],
+            point_cloud_range=[0.0, 0.0, -2.0, 4.0, 4.0, 2.0],
+            max_num_points=2,
+            max_voxels=1,
+            eval_max_voxels=8,
+            voxelization_z_order_first=True,
+        )
+        # Three points in three distinct pillars
+        points = torch.tensor(
+            [
+                [0.1, 0.1, 0.0, 1.0],
+                [1.1, 1.1, 0.0, 2.0],
+                [2.1, 2.1, 0.0, 3.0],
+            ],
+            dtype=torch.float32,
+        )
+
+        train_outputs = preprocessor({"points": [points]}, is_training=True)
+        self.assertEqual(train_outputs["voxels"].shape[0], 1)
+
+        eval_outputs = preprocessor({"points": [points]}, is_training=False)
+        self.assertEqual(eval_outputs["voxels"].shape[0], 3)
+
+    def test_eval_mode_without_eval_max_voxels_raises(self) -> None:
+        """
+        Test that running in evaluation mode without an explicit ``eval_max_voxels`` raises
+        instead of silently reusing the training budget.
+        """
+        batch = {"points": [torch.tensor([[0.5, 0.5, 0.0, 1.0]], dtype=torch.float32)]}
+
+        with self.assertRaises(ValueError):
+            self.point_pillar_preprocessor(batch, is_training=False)
+
+    def test_train_mode_does_not_require_eval_max_voxels(self) -> None:
+        """
+        Test that training-mode forward keeps working when ``eval_max_voxels`` is not set,
+        so existing training configs stay valid.
+        """
+        batch = {"points": [torch.tensor([[0.5, 0.5, 0.0, 1.0]], dtype=torch.float32)]}
+
+        outputs = self.point_pillar_preprocessor(batch, is_training=True)
+
+        self.assertEqual(outputs["voxels"].shape[0], 1)
 
     def test_passthrough_of_existing_keys(self) -> None:
         """
@@ -109,7 +159,7 @@ class TestPointPillarPreprocessor(unittest.TestCase):
             "points": [torch.tensor([[0.5, 0.5, 0.0, 1.0]], dtype=torch.float32)],
             "gt_boxes": sentinel,
         }
-        outputs = self.point_pillar_preprocessor(batch)
+        outputs = self.point_pillar_preprocessor(batch, is_training=True)
         self.assertIs(outputs["gt_boxes"], sentinel)
 
 

--- a/autoware_ml/preprocessing/segmentation3d/frustum_range.py
+++ b/autoware_ml/preprocessing/segmentation3d/frustum_range.py
@@ -57,7 +57,9 @@ class FrustumRangePreprocessor:
         self.ignore_index = int(ignore_index)
         self.num_classes = int(num_classes)
 
-    def __call__(self, batch_inputs_dict: dict[str, Any]) -> dict[str, Any]:
+    def __call__(
+        self, batch_inputs_dict: dict[str, Any], *, is_training: bool = False
+    ) -> dict[str, Any]:
         """Project concatenated point clouds into FRNet range-view tensors.
 
         Reads the concatenated batch produced by :meth:`DataModule.collate_fn`,
@@ -71,6 +73,8 @@ class FrustumRangePreprocessor:
             batch_inputs_dict: Batch dictionary containing the concatenated
                 ``points`` tensor, the cumulative per-sample ``offset``
                 tensor, and an optional concatenated ``pts_semantic_mask``.
+            is_training: Accepted for pipeline-contract compatibility; the
+                projection is mode-independent, so the value is unused.
 
         Returns:
             Dictionary with:

--- a/autoware_ml/tests/framework/test_model_predictions.py
+++ b/autoware_ml/tests/framework/test_model_predictions.py
@@ -13,7 +13,8 @@ from autoware_ml.preprocessing.base import DataPreprocessing
 
 
 class _AddPreprocessedFeature:
-    def __call__(self, batch_inputs_dict: dict[str, Any]) -> dict[str, Any]:
+    def __call__(self, batch_inputs_dict: dict[str, Any], *, is_training: bool) -> dict[str, Any]:
+        del is_training
         return {"x": batch_inputs_dict["x"] + 1.0, "preprocessed": torch.tensor(True)}
 
 

--- a/autoware_ml/tests/preprocessing/test_data_preprocessing.py
+++ b/autoware_ml/tests/preprocessing/test_data_preprocessing.py
@@ -1,0 +1,65 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the DataPreprocessing pipeline wrapper."""
+
+from typing import Any
+
+import pytest
+
+from autoware_ml.preprocessing.base import DataPreprocessing
+
+
+class _ModeRecorder:
+    """Minimal pipeline stage that records the mode it was called with."""
+
+    def __init__(self) -> None:
+        self.seen_modes: list[bool] = []
+
+    def __call__(self, batch_inputs_dict: dict[str, Any], *, is_training: bool) -> dict[str, Any]:
+        self.seen_modes.append(is_training)
+        return {"stage_ran": True}
+
+
+def test_call_forwards_is_training_to_every_layer():
+    """The pipeline is not a registered submodule, so the owning model's mode reaches
+    the stages only through the explicit is_training argument."""
+    first, second = _ModeRecorder(), _ModeRecorder()
+    pipeline = DataPreprocessing([first, second])
+
+    pipeline({}, is_training=True)
+    pipeline({}, is_training=False)
+
+    assert first.seen_modes == [True, False]
+    assert second.seen_modes == [True, False]
+
+
+def test_call_requires_explicit_is_training():
+    """The mode must be stated on every call; forgetting it is an immediate TypeError
+    instead of silently running in the wrong mode."""
+    pipeline = DataPreprocessing([_ModeRecorder()])
+
+    with pytest.raises(TypeError):
+        pipeline({})  # type: ignore[call-arg]
+
+
+def test_call_merges_layer_outputs_into_batch():
+    pipeline = DataPreprocessing([_ModeRecorder()])
+    batch = {"points": [1, 2, 3]}
+
+    result = pipeline(batch, is_training=True)
+
+    assert result is batch  # mutated in place and returned for chaining
+    assert result["stage_ran"] is True
+    assert result["points"] == [1, 2, 3]

--- a/autoware_ml/tests/preprocessing/test_segmentation3d.py
+++ b/autoware_ml/tests/preprocessing/test_segmentation3d.py
@@ -60,7 +60,7 @@ class TestFrustumRangePreprocessor:
             sample_labels=[torch.tensor([3, 3, 1], dtype=torch.long)],
         )
 
-        outputs = preprocessor(batch_inputs)
+        outputs = preprocessor(batch_inputs, is_training=False)
 
         assert outputs["points"].shape == (3, 4)
         assert outputs["coors"].shape == (3, 3)
@@ -92,7 +92,7 @@ class TestFrustumRangePreprocessor:
             ],
         )
 
-        outputs = preprocessor(batch_inputs)
+        outputs = preprocessor(batch_inputs, is_training=False)
 
         assert outputs["points"].shape == (3, 4)
         assert outputs["pts_semantic_mask"].shape == (3,)
@@ -113,7 +113,7 @@ class TestFrustumRangePreprocessor:
             sample_points=[torch.tensor([[1.0, 0.0, 0.0, 0.1]], dtype=torch.float32)]
         )
 
-        outputs = preprocessor(batch_inputs)
+        outputs = preprocessor(batch_inputs, is_training=False)
 
         assert "pts_semantic_mask" not in outputs
         assert "semantic_seg" not in outputs
@@ -137,7 +137,7 @@ class TestFrustumRangePreprocessor:
             sample_labels=[torch.tensor([-1, 2], dtype=torch.long)],
         )
 
-        outputs = preprocessor(batch_inputs)
+        outputs = preprocessor(batch_inputs, is_training=False)
 
         assert outputs["semantic_seg"].shape == (1, 2, 4)
         assert (outputs["semantic_seg"] == 2).any()
@@ -163,7 +163,7 @@ class TestFrustumRangePreprocessor:
             sample_labels=[torch.tensor([255, 255, 1], dtype=torch.long)],
         )
 
-        outputs = preprocessor(batch_inputs)
+        outputs = preprocessor(batch_inputs, is_training=False)
 
         assert outputs["semantic_seg"][0, 1, 2].item() == 255
         assert outputs["semantic_seg"][0, 1, 1].item() == 1

--- a/autoware_ml/tests/transforms/test_point_cloud.py
+++ b/autoware_ml/tests/transforms/test_point_cloud.py
@@ -163,6 +163,76 @@ class TestPointCloudTransforms:
         assert np.allclose(points[:2, 4], 0.0)
         assert np.allclose(points[2:, 4], 0.1)
 
+    def test_multi_sweeps_remove_close_removes_axis_aligned_box(self):
+        """The removed region is the box |x|,|y| < close_radius, not a radial circle:
+        (0.9, 0.9) lies outside the r=1.0 circle but inside the box, so only the box
+        semantics remove it."""
+        key_points = np.array([[5.0, 5.0, 0.0, 0.0]], dtype=np.float32)
+        sweep_points = np.array(
+            [
+                [0.9, 0.9, 0.0, 0.0],  # inside the box, outside the circle -> removed
+                [0.5, -0.5, 0.0, 0.0],  # inside the box -> removed
+                [1.05, 0.0, 0.0, 0.0],  # |x| >= radius -> kept
+                [0.0, -1.2, 0.0, 0.0],  # |y| >= radius -> kept
+            ],
+            dtype=np.float32,
+        )
+
+        transform = LoadPointsFromMultiSweeps(
+            sweeps_num=2,
+            load_dim=4,
+            use_dim=[0, 1, 2, 3],
+            remove_close=True,
+            close_radius=1.0,
+        )
+        output = transform({"points": key_points, "sweeps": [{"points": sweep_points}]})
+
+        points = output["points"]
+        # key point + the two sweep points outside the box
+        assert points.shape == (3, 4)
+        assert not np.any(np.all(np.isclose(points[:, :2], [0.9, 0.9]), axis=1))
+        assert np.any(np.all(np.isclose(points[:, :2], [1.05, 0.0]), axis=1))
+        assert np.any(np.all(np.isclose(points[:, :2], [0.0, -1.2]), axis=1))
+
+    def test_multi_sweeps_takes_nearest_sweeps_in_test_mode(self):
+        sweeps = [
+            {"points": np.full((1, 4), 10.0, dtype=np.float32)},
+            {"points": np.full((1, 4), 20.0, dtype=np.float32)},
+            {"points": np.full((1, 4), 30.0, dtype=np.float32)},
+        ]
+        transform = LoadPointsFromMultiSweeps(sweeps_num=2, load_dim=4, use_dim=[0, 1, 2, 3])
+
+        output = transform({"points": np.zeros((1, 4), dtype=np.float32), "sweeps": sweeps})
+
+        # test_mode defaults to True: always the nearest sweep, never a random one
+        assert output["points"].shape == (2, 4)
+        assert np.allclose(output["points"][1], 10.0)
+
+    def test_multi_sweeps_samples_sweeps_randomly_when_not_test_mode(self, monkeypatch):
+        sweeps = [
+            {"points": np.full((1, 4), 10.0, dtype=np.float32)},
+            {"points": np.full((1, 4), 20.0, dtype=np.float32)},
+            {"points": np.full((1, 4), 30.0, dtype=np.float32)},
+        ]
+        calls = {}
+
+        def fake_choice(num_entries, size, replace):
+            calls["args"] = (num_entries, size, replace)
+            return np.array([2])
+
+        monkeypatch.setattr(
+            "autoware_ml.transforms.point_cloud.sweeps.np.random.choice", fake_choice
+        )
+        transform = LoadPointsFromMultiSweeps(
+            sweeps_num=2, load_dim=4, use_dim=[0, 1, 2, 3], test_mode=False
+        )
+
+        output = transform({"points": np.zeros((1, 4), dtype=np.float32), "sweeps": sweeps})
+
+        # Sampled uniformly without replacement across all entries, not sliced to the nearest
+        assert calls["args"] == (3, 1, False)
+        assert np.allclose(output["points"][1], 30.0)
+
     def test_multi_sweeps_time_dim_requires_key_timestamp(self):
         transform = LoadPointsFromMultiSweeps(
             sweeps_num=2, load_dim=5, use_dim=[0, 1, 2, 3, 4], time_dim=4

--- a/autoware_ml/transforms/point_cloud/sweeps.py
+++ b/autoware_ml/transforms/point_cloud/sweeps.py
@@ -48,7 +48,7 @@ class LoadPointsFromMultiSweeps(BaseTransform):
         pad_empty_sweeps: bool = False,
         remove_close: bool = False,
         close_radius: float = 1.0,
-        selection: str = "nearest",
+        test_mode: bool = True,
     ) -> None:
         """Initialize the LoadPointsFromMultiSweeps transform.
 
@@ -63,11 +63,9 @@ class LoadPointsFromMultiSweeps(BaseTransform):
             remove_close: Whether to drop sweep points close to the origin.
             close_radius: Half-width in meters of the removed region when
                 ``remove_close`` is enabled.
-            selection: How to pick the appended sweeps from the available
-                entries: ``"nearest"`` takes the closest ones in time;
-                ``"random"`` samples them uniformly without replacement (a
-                temporal-jitter augmentation for training, matching mmdet3d's
-                train-time behavior).
+            test_mode: How to pick the appended sweeps from the available
+                entries. ``True`` takes the nearest ones in time; ``False``
+                samples them uniformly without replacement.
         """
         self.sweeps_num = sweeps_num
         self.load_dim = load_dim
@@ -78,9 +76,7 @@ class LoadPointsFromMultiSweeps(BaseTransform):
         self.pad_empty_sweeps = pad_empty_sweeps
         self.remove_close = remove_close
         self.close_radius = close_radius
-        if selection not in {"nearest", "random"}:
-            raise ValueError(f"selection must be 'nearest' or 'random', got {selection!r}.")
-        self.selection = selection
+        self.test_mode = test_mode
 
     def apply_defaults(self, input_dict: dict[str, Any]) -> None:
         """Load the current-frame point cloud when it is not present yet."""
@@ -120,7 +116,7 @@ class LoadPointsFromMultiSweeps(BaseTransform):
             return input_dict
 
         needed = max(0, self.sweeps_num - 1)
-        if self.selection == "random" and len(sweep_entries) > needed:
+        if not self.test_mode and len(sweep_entries) > needed:
             indices = np.random.choice(len(sweep_entries), needed, replace=False)
             selected_sweeps = [sweep_entries[i] for i in indices]
         else:

--- a/autoware_ml/transforms/point_cloud/sweeps.py
+++ b/autoware_ml/transforms/point_cloud/sweeps.py
@@ -48,6 +48,7 @@ class LoadPointsFromMultiSweeps(BaseTransform):
         pad_empty_sweeps: bool = False,
         remove_close: bool = False,
         close_radius: float = 1.0,
+        selection: str = "nearest",
     ) -> None:
         """Initialize the LoadPointsFromMultiSweeps transform.
 
@@ -60,7 +61,13 @@ class LoadPointsFromMultiSweeps(BaseTransform):
                 relative to the current frame before ``use_dim`` selection.
             pad_empty_sweeps: Whether to repeat the current frame when no sweeps exist.
             remove_close: Whether to drop sweep points close to the origin.
-            close_radius: Radius in meters used when ``remove_close`` is enabled.
+            close_radius: Half-width in meters of the removed region when
+                ``remove_close`` is enabled.
+            selection: How to pick the appended sweeps from the available
+                entries: ``"nearest"`` takes the closest ones in time;
+                ``"random"`` samples them uniformly without replacement (a
+                temporal-jitter augmentation for training, matching mmdet3d's
+                train-time behavior).
         """
         self.sweeps_num = sweeps_num
         self.load_dim = load_dim
@@ -71,6 +78,9 @@ class LoadPointsFromMultiSweeps(BaseTransform):
         self.pad_empty_sweeps = pad_empty_sweeps
         self.remove_close = remove_close
         self.close_radius = close_radius
+        if selection not in {"nearest", "random"}:
+            raise ValueError(f"selection must be 'nearest' or 'random', got {selection!r}.")
+        self.selection = selection
 
     def apply_defaults(self, input_dict: dict[str, Any]) -> None:
         """Load the current-frame point cloud when it is not present yet."""
@@ -109,7 +119,12 @@ class LoadPointsFromMultiSweeps(BaseTransform):
             input_dict["points"] = self._select_dims(points)
             return input_dict
 
-        selected_sweeps = sweep_entries[: max(0, self.sweeps_num - 1)]
+        needed = max(0, self.sweeps_num - 1)
+        if self.selection == "random" and len(sweep_entries) > needed:
+            indices = np.random.choice(len(sweep_entries), needed, replace=False)
+            selected_sweeps = [sweep_entries[i] for i in indices]
+        else:
+            selected_sweeps = sweep_entries[:needed]
         sweep_points = [points]
         for sweep in selected_sweeps:
             sweep_array = self._load_sweep_points(sweep).copy()
@@ -149,6 +164,11 @@ class LoadPointsFromMultiSweeps(BaseTransform):
         return points
 
     def _remove_close_points(self, points: npt.NDArray[np.float32]) -> npt.NDArray[np.float32]:
-        """Remove points close to the origin in the xy plane."""
-        radius = np.linalg.norm(points[:, :2], axis=1)
-        return points[radius >= self.close_radius]
+        """Remove points close to the origin in the xy plane.
+
+        The removed region is the axis-aligned box |x|, |y| < close_radius
+        """
+        close = (np.abs(points[:, 0]) < self.close_radius) & (
+            np.abs(points[:, 1]) < self.close_radius
+        )
+        return points[~close]


### PR DESCRIPTION
## What

Fixes a set of silent deviations from the reference (mmdet3d) BEVFusion that
were introduced during the migration. Found by running the same reference
BEVFusion 2.8 checkpoint through both frameworks and chasing every output
difference to its root cause.

| Fix | Before | After | Evidence |
|---|---|---|---|
| Decoder positional embeddings | baked into the tokens once; the residual stream carries them | DETR/TransFusion semantics: residual stream stays position-free, embeddings added to q/k/v at every attention call | Not an equivalent function — with identical weights the old math produced 354 boxes where the reference produces 113 |
| `remove_close` region | radial circle | axis-aligned box `\|x\|,\|y\| < radius` | nuScenes-devkit `PointCloud.remove_close` is a box (its docstring says "radius", the code is a box); mmdet3d/OpenPCDet/CenterPoint all inherit it — the circle came from implementing the docstring |
| Circle-NMS radius (j6gen2) | 0.25 | 0.5 (+ comment) | mmdet3d's `circle_nms` threshold is a **squared** distance, so its 0.25 means a 0.5 m Euclidean radius — the value was copied without translating the semantics, halving the intended suppression radius |
| `dense_heatmap_pooling_classes` (j6gen2) | car, truck, bus | + barrier | the trained reference recipe includes barrier |
| Prediction-head hidden width | hardcoded `= in_channels` (128) | configurable (`head_hidden_channels`), j6gen2 sets the reference value 64 | mmdet3d's `SeparateHead` has this degree of freedom (`head_conv`, default 64); the port lost the parameter and silently doubled the width |
| Head BN epsilon | hardcoded 1e-3 | configurable (`norm_eps`), j6gen2 sets 1e-5 | 1e-3 is an mmcv-ism; the reference heads use the PyTorch default 1e-5 |
| Sweep selection at train time | always nearest | `selection: random` in the bevfusion train pipelines | matches mmdet3d's train-time behavior: temporal-jitter augmentation (robustness to frame drops) that also keeps the per-point time-lag channel informative |
| Voxel budget at evaluation | single `max_voxels` 120k for train and eval | `eval_max_voxels` 160k (train stays 120k) | typical j6gen2 val frames occupy 120k–136k voxels, so evaluation silently truncated ~10% of them; the reference uses `max_voxels=[120000, 160000]` |

Supporting change: the (deliberately unregistered) `DataPreprocessing`
pipeline now mirrors the owning model's train/eval mode — without this,
`model.eval()` never reached the preprocessor and any train/eval-dependent
preprocessing was silently stuck in training mode.

All new parameters default to the previous behavior; only the bevfusion
configs opt into the corrected values. Existing checkpoints of other tasks are
unaffected (note: any checkpoint trained with the old decoder math would
change behavior on the new code — none is known to be in use).

## Verification

- Root causes were isolated with a weight-level checkpoint conversion study
  (AWML BEVFusion 2.8 → autoware-ml): with these fixes (plus temporary shims
  for the two remaining intentional architecture differences — shared-conv
  norm/act and heatmap border handling), the reference checkpoint reproduces
  113/113 boxes on the parity sample and val mAP/mAPH matching the reference
  evaluation to ±0.0004.
- Occupied-voxel counts measured on j6gen2 val confirm the evaluation
  truncation (5 samples: 113k / 120k / 131k / 136k / 132k vs the 120k budget).
- Training smoke test on the j6gen2 lidar config (10 train + 2 val batches,
  batch size 4, single GPU): runs end to end with finite losses
  (train/loss 18.6 at start), exercising the random sweep selection, the
  64-wide heads, the corrected decoder math, and the eval voxel budget.

The end-to-end verification numbers above were produced together with #82
(sweep transform fix) and #84 (gt_num_points collation fix); this PR is
independent of both at the code level.