### PR TITLE
feat(deploy): add deploy.onnx.precision option for explicit-fp16 exports

### DIFF
--- a/autoware_ml/configs/defaults/modules/deploy.yaml
+++ b/autoware_ml/configs/defaults/modules/deploy.yaml
@@ -6,6 +6,7 @@ deploy:
     dynamo: true
     opset_version: 21
     modify_graph: null
+    precision: fp32
   tensorrt:
     enabled: true
     workspace_size: 4294967296

--- a/autoware_ml/scripts/deploy.py
+++ b/autoware_ml/scripts/deploy.py
@@ -37,6 +37,11 @@ from autoware_ml.utils.deploy import (
     supports_export_stage,
     validate_cuda_available,
 )
+from autoware_ml.utils.onnx_precision import (
+    convert_onnx_precision,
+    resolve_onnx_precision,
+    should_convert_precision,
+)
 from autoware_ml.utils.mlflow_helpers import (
     AUTOWARE_ML_RUN_ID_ENV,
     build_run_metadata,
@@ -230,6 +235,13 @@ def main(cfg: DictConfig) -> None:
                     modify_graph_cfg = module_onnx_cfg.get("modify_graph", None)
                     if should_modify_graph(modify_graph_cfg):
                         module_onnx_path = modify_onnx_graph(module_onnx_path, modify_graph_cfg)
+
+                    # Precision conversion runs last so graph modifiers keep operating on the
+                    # fp32 export they were written against.
+                    if should_convert_precision(module_onnx_cfg):
+                        module_onnx_path = convert_onnx_precision(
+                            module_onnx_path, resolve_onnx_precision(module_onnx_cfg)
+                        )
 
             if should_export_stage(deploy_cfg.tensorrt):
                 if not supports_export_stage(export_spec, "tensorrt"):

--- a/autoware_ml/tests/utils/test_onnx_precision.py
+++ b/autoware_ml/tests/utils/test_onnx_precision.py
@@ -1,0 +1,136 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for export-time ONNX precision conversion."""
+
+from __future__ import annotations
+
+import numpy as np
+import onnx
+import pytest
+from omegaconf import OmegaConf
+from onnx import TensorProto, helper, numpy_helper
+
+from autoware_ml.utils.onnx_precision import (
+    OnnxPrecision,
+    convert_onnx_precision,
+    resolve_onnx_precision,
+    should_convert_precision,
+)
+
+
+def _make_fp32_model() -> onnx.ModelProto:
+    """A minimal fp32 graph exercising the conversion pitfalls.
+
+    MatMul with an fp32 weight initializer, followed by a pre-existing no-op Cast(to=FLOAT)
+    (the pattern torch exports for ``.to(query.dtype)``), whose output is both a graph output
+    and an internal input to a second MatMul — mirroring PTv3's dual-use point_feat_0.
+    """
+    weight = numpy_helper.from_array(np.eye(4, dtype=np.float32), name="weight")
+    nodes = [
+        helper.make_node("MatMul", ["x", "weight"], ["mm0"], name="mm0"),
+        helper.make_node("Cast", ["mm0"], ["feat"], name="noop_cast", to=TensorProto.FLOAT),
+        helper.make_node("MatMul", ["feat", "weight"], ["out"], name="mm1"),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "tiny",
+        inputs=[helper.make_tensor_value_info("x", TensorProto.FLOAT, [None, 4])],
+        outputs=[
+            helper.make_tensor_value_info("feat", TensorProto.FLOAT, [None, 4]),
+            helper.make_tensor_value_info("out", TensorProto.FLOAT, [None, 4]),
+        ],
+        initializer=[weight],
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+
+
+def test_resolve_precision_defaults_to_fp32() -> None:
+    assert resolve_onnx_precision(OmegaConf.create({})) is OnnxPrecision.FP32
+    assert not should_convert_precision(OmegaConf.create({}))
+
+
+def test_resolve_precision_reads_config_string() -> None:
+    """The enum's values are the spellings used in deploy.onnx.precision."""
+    cfg = OmegaConf.create({"precision": "fp16"})
+    assert resolve_onnx_precision(cfg) is OnnxPrecision.FP16
+    assert should_convert_precision(cfg)
+
+
+def test_resolve_precision_rejects_unsupported() -> None:
+    with pytest.raises(ValueError, match="int8"):
+        resolve_onnx_precision(OmegaConf.create({"precision": "int8"}))
+
+
+def test_fp16_conversion(tmp_path) -> None:
+    onnx_path = tmp_path / "tiny.onnx"
+    onnx.save(_make_fp32_model(), onnx_path.as_posix())
+
+    result = convert_onnx_precision(onnx_path, OnnxPrecision.FP16)
+    model = onnx.load(result.as_posix())
+
+    initializer_types = {i.name: i.data_type for i in model.graph.initializer}
+    assert initializer_types["weight"] == TensorProto.FLOAT16
+
+    # The graph boundary stays fp32: reduced precision is internal, behind cast layers, so
+    # consumers keep their fp32 buffers.
+    for value_info in list(model.graph.input) + list(model.graph.output):
+        assert value_info.type.tensor_type.elem_type == TensorProto.FLOAT
+
+    # 'feat' is both a graph output and an internal input of the second MatMul. The output must
+    # be produced by an fp16->fp32 cast, while the internal consumer must read the pre-cast fp16
+    # tensor - otherwise a strongly typed parse rejects the mixed Float/Half MatMul.
+    producers = {output: node for node in model.graph.node for output in node.output}
+    feat_producer = producers["feat"]
+    assert feat_producer.op_type == "Cast"
+    assert next(a.i for a in feat_producer.attribute if a.name == "to") == TensorProto.FLOAT
+    internal_consumers = [
+        n for n in model.graph.node if "feat" in n.input and n is not feat_producer
+    ]
+    assert not internal_consumers, "internal consumers must be rewired to the fp16 tensor"
+    mm1 = next(n for n in model.graph.node if n.name == "mm1")
+    assert mm1.input[0] == feat_producer.input[0]
+
+    onnx.checker.check_model(model)
+
+
+def test_fp16_conversion_rejects_subgraphs(tmp_path) -> None:
+    """Models with If/Loop/Scan subgraphs are refused: the cast fixups only handle the top level."""
+    const = helper.make_node(
+        "Constant",
+        [],
+        ["y"],
+        value=helper.make_tensor("v", TensorProto.FLOAT, [1], [1.0]),
+    )
+    branch = helper.make_graph(
+        [const],
+        "branch",
+        inputs=[],
+        outputs=[helper.make_tensor_value_info("y", TensorProto.FLOAT, [1])],
+    )
+    if_node = helper.make_node(
+        "If", ["cond"], ["y"], name="if0", then_branch=branch, else_branch=branch
+    )
+    graph = helper.make_graph(
+        [if_node],
+        "with_subgraph",
+        inputs=[helper.make_tensor_value_info("cond", TensorProto.BOOL, [])],
+        outputs=[helper.make_tensor_value_info("y", TensorProto.FLOAT, [1])],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    onnx_path = tmp_path / "subgraph.onnx"
+    onnx.save(model, onnx_path.as_posix())
+
+    with pytest.raises(NotImplementedError, match="if0"):
+        convert_onnx_precision(onnx_path, OnnxPrecision.FP16)

--- a/autoware_ml/utils/deploy.py
+++ b/autoware_ml/utils/deploy.py
@@ -431,6 +431,8 @@ def create_tensorrt_builder_config(tensorrt_cfg: DictConfig) -> tuple[Any, Any, 
     trt_logger = trt.Logger(trt.Logger.WARNING)
     trt.init_libnvinfer_plugins(trt_logger, "")
     builder = trt.Builder(trt_logger)
+    # Always strongly typed: deploy.onnx.precision decides which dtypes the ONNX carries, and the
+    # engine has to use them as exported rather than let the builder reassign precisions.
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     parser = trt.OnnxParser(network, trt_logger)
     config = builder.create_builder_config()

--- a/autoware_ml/utils/onnx_precision.py
+++ b/autoware_ml/utils/onnx_precision.py
@@ -1,0 +1,175 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Explicit-precision conversion for exported ONNX models.
+
+``deploy.onnx.precision`` controls the float dtypes baked into the exported ONNX.
+The TensorRT stage always builds strongly typed, so those dtypes are what the
+engine uses: the exported ONNX alone decides the engine's numerics.
+
+All float network inputs/outputs always stay FP32, so inference code works
+with all model precisions without interface changes.
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import StrEnum, auto
+from pathlib import Path
+from typing import Any
+
+import onnx
+from onnxconverter_common import float16
+
+logger = logging.getLogger(__name__)
+
+
+class OnnxPrecision(StrEnum):
+    """
+    Float precision baked into an exported ONNX.
+
+    Attributes:
+      FP32: Export the model unchanged.
+      FP16: Convert weights and internal tensors to half precision, keeping graph I/O fp32.
+    """
+
+    FP32 = auto()
+    FP16 = auto()
+
+
+def resolve_onnx_precision(onnx_cfg: Any) -> OnnxPrecision:
+    """Read and validate ``deploy.onnx.precision`` (default fp32, the historical behavior)."""
+    precision = str(onnx_cfg.get("precision", OnnxPrecision.FP32))
+    try:
+        return OnnxPrecision(precision)
+    except ValueError:
+        raise ValueError(
+            f"Unsupported deploy.onnx.precision '{precision}'. Supported values: "
+            f"{', '.join(OnnxPrecision)}. Precisions that require calibration (e.g. int8) "
+            "are out of scope for export-time conversion."
+        ) from None
+
+
+def should_convert_precision(onnx_cfg: Any) -> bool:
+    """Return whether the exported ONNX needs a precision conversion pass."""
+    return resolve_onnx_precision(onnx_cfg) != OnnxPrecision.FP32
+
+
+def convert_onnx_precision(onnx_path: str | Path, precision: OnnxPrecision) -> Path:
+    """Convert an exported fp32 ONNX to the requested explicit precision, in place."""
+    if precision == OnnxPrecision.FP16:
+        return _convert_to_fp16(Path(onnx_path))
+    raise ValueError(f"No conversion implemented for precision '{precision}'.")
+
+
+def _convert_to_fp16(onnx_path: Path) -> Path:
+    model = onnx.load(onnx_path.as_posix())
+
+    # The cast-fixup passes below only handle the top-level graph. No autoware-ml model uses
+    # subgraphs, so refuse them explicitly instead of converting them incorrectly.
+    subgraph_nodes = [
+        node.name or node.op_type
+        for node in model.graph.node
+        for attribute in node.attribute
+        if attribute.type in (onnx.AttributeProto.GRAPH, onnx.AttributeProto.GRAPHS)
+    ]
+    if subgraph_nodes:
+        raise NotImplementedError(
+            "fp16 conversion does not support models with subgraphs (If/Loop/Scan); "
+            f"found: {', '.join(subgraph_nodes)}"
+        )
+
+    # keep_io_types keeps the graph boundary fp32 via cast layers inside the model, so engine
+    # I/O and consumers' buffers stay fp32 regardless of the internal precision.
+    #
+    # The op block list must be empty: custom plugin ops negotiate their own precisions and
+    # support fp16 I/O natively, and the default block list creates fp32 islands whose boundary
+    # casts the converter places incorrectly around ops it cannot shape-infer.
+    converted = float16.convert_float_to_float16(
+        model,
+        keep_io_types=True,
+        op_block_list=[],
+        disable_shape_infer=True,  # custom plugin ops break ONNX shape inference
+    )
+
+    n_rewired = _rewire_dual_use_outputs(converted)
+    n_recast = _retarget_stray_float_casts(converted)
+    logger.info(
+        "Converted %s to fp16 with fp32 graph I/O (rewired %d dual-use output consumer(s), "
+        "retargeted %d pre-existing float cast(s))",
+        onnx_path,
+        n_rewired,
+        n_recast,
+    )
+
+    onnx.save(converted, onnx_path.as_posix())
+    return onnx_path
+
+
+def _rewire_dual_use_outputs(model: Any) -> int:
+    """Rewire internal consumers of fp32 graph outputs to the pre-cast fp16 tensor.
+
+    A graph output can double as an internal input (e.g. PTv3's point_feat_0 feeds the next
+    encoder stage). keep_io_types casts such outputs back to fp32, which would re-enter the fp16
+    interior as fp32 and fail a strongly typed parse; internal consumers must read the fp16
+    tensor the output cast was fed from instead.
+    """
+    graph_outputs = {output.name for output in model.graph.output}
+    producers = {output: node for node in model.graph.node for output in node.output}
+    n_rewired = 0
+    for name in graph_outputs:
+        producer = producers.get(name)
+        if producer is None or producer.op_type != "Cast":
+            continue
+        cast_target = next((a.i for a in producer.attribute if a.name == "to"), None)
+        if cast_target != onnx.TensorProto.FLOAT:
+            continue
+        pre_cast_tensor = producer.input[0]
+        consumers = [
+            (node, index)
+            for node in model.graph.node
+            if node is not producer
+            for index, node_input in enumerate(node.input)
+            if node_input == name
+        ]
+        for node, index in consumers:
+            node.input[index] = pre_cast_tensor
+        n_rewired += len(consumers)
+    return n_rewired
+
+
+def _retarget_stray_float_casts(model: Any) -> int:
+    """Retarget pre-existing ``Cast(to=FLOAT)`` nodes (and float ConstantOfShape values) to fp16.
+
+    ``float16.convert_float_to_float16`` leaves the ``to`` attribute of Cast nodes untouched.
+    Exports commonly contain fp32->fp32 no-op casts (e.g. the post-softmax ``.to(query.dtype)``
+    in attention). After conversion these would cast fp16->fp32, feeding the wrong precision to
+    consumers. Casts that produce a graph output are the fp32 boundary and stay untouched.
+    """
+    graph_outputs = {output.name for output in model.graph.output}
+    n_recast = 0
+    for node in model.graph.node:
+        if node.op_type == "Cast":
+            if any(output in graph_outputs for output in node.output):
+                continue
+            for attribute in node.attribute:
+                if attribute.name == "to" and attribute.i == onnx.TensorProto.FLOAT:
+                    attribute.i = onnx.TensorProto.FLOAT16
+                    n_recast += 1
+        elif node.op_type == "ConstantOfShape":
+            for attribute in node.attribute:
+                if attribute.name == "value" and attribute.t.data_type == onnx.TensorProto.FLOAT:
+                    value = onnx.numpy_helper.to_array(attribute.t)
+                    attribute.t.CopyFrom(onnx.numpy_helper.from_array(value.astype("float16")))
+    return n_recast

--- a/docs/user-guide/deployment.md
+++ b/docs/user-guide/deployment.md
@@ -102,11 +102,20 @@ deploy:
     enabled: true
     dynamo: true
     opset_version: 21
+    precision: fp32
     input_names: [input]
     output_names: [output]
     dynamic_shapes:
       input_tensor: { 2: height, 3: width }
 ```
+
+**precision**: `fp32` exports the model unchanged. `fp16` halves the weights and
+internal tensors but keeps graph inputs and outputs fp32, so consumers keep their
+fp32 buffers either way. Calibrated precisions such as `int8` are out of scope here.
+
+An fp16 export only works if the inference engine honors its dtypes instead of
+reassigning them — in Autoware, that means `trt_precision: strongly-typed` on the
+node.
 
 **dynamic_shapes**: Keys are exported input names, values map dimension indices
 to symbolic names. For the default export path these names come from
@@ -143,6 +152,10 @@ deploy:
 
 !!! tip
     TensorRT optimizes most aggressively for `opt_shape`. Set this to your typical inference resolution.
+
+Engines are always built strongly typed: the builder uses exactly the precisions
+the ONNX carries and never picks its own. Choose the engine's numerics with
+`deploy.onnx.precision`.
 
 ## Model-Owned Export Wrappers
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -146,6 +146,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d6/2b/021dcd2dd50c3c71b7959d7368526da384a295c162fb4863f36057973f78/onnx-1.21.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://pypi.nvidia.com/onnx-graphsurgeon/onnx_graphsurgeon-0.5.8-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/df/a99736bcca6b16e36c687ce4996abcf4ce73c514fddd9e730cfcb6a334f2/onnx_ir-0.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4a/67/8dca1868a6e226f8d3f7d666cb6a48b79a60aad5267b16b24627cd8d9eb8/onnxconverter_common-1.16.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/13/e080d758f2b60f71abe518c707135fb121d6a3019e0761ead89b5283ac3d/onnxruntime_gpu-1.24.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/66/56/e6b179397497ab93266b6eb00743403a6a699a29063a423c4a14595d3db9/onnxscript-0.6.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dd/5c/c139a7876099916879609372bfa513b7f1257f7f1a908b0bdc1c2328241b/opencv_python_headless-4.11.0.86-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -409,6 +410,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d6/2b/021dcd2dd50c3c71b7959d7368526da384a295c162fb4863f36057973f78/onnx-1.21.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://pypi.nvidia.com/onnx-graphsurgeon/onnx_graphsurgeon-0.5.8-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/df/a99736bcca6b16e36c687ce4996abcf4ce73c514fddd9e730cfcb6a334f2/onnx_ir-0.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4a/67/8dca1868a6e226f8d3f7d666cb6a48b79a60aad5267b16b24627cd8d9eb8/onnxconverter_common-1.16.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/13/e080d758f2b60f71abe518c707135fb121d6a3019e0761ead89b5283ac3d/onnxruntime_gpu-1.24.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/66/56/e6b179397497ab93266b6eb00743403a6a699a29063a423c4a14595d3db9/onnxscript-0.6.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dd/5c/c139a7876099916879609372bfa513b7f1257f7f1a908b0bdc1c2328241b/opencv_python_headless-4.11.0.86-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -2773,6 +2775,21 @@ packages:
   - ml-dtypes>=0.5.0
   - sympy>=1.13
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/4a/67/8dca1868a6e226f8d3f7d666cb6a48b79a60aad5267b16b24627cd8d9eb8/onnxconverter_common-1.16.0-py2.py3-none-any.whl
+  name: onnxconverter-common
+  version: 1.16.0
+  sha256: df39ee96f17fff119dff10dd245467651b60b9e8a96020eb93402239794852f7
+  requires_dist:
+  - numpy
+  - onnx
+  - packaging
+  - protobuf>=3.20.2
+  - pytest ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - ruff ; extra == 'lint'
+  - pyright ; extra == 'lint'
+  - onnxconverter-common[lint,test] ; extra == 'dev'
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/9f/13/e080d758f2b60f71abe518c707135fb121d6a3019e0761ead89b5283ac3d/onnxruntime_gpu-1.24.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
   name: onnxruntime-gpu
   version: 1.24.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "optuna==4.8.0",
     "onnx==1.21.0",
     "onnx_graphsurgeon==0.5.8",
+    "onnxconverter-common==1.16.0",
     "onnxruntime-gpu==1.24.4",
     "onnxscript==0.6.2",
     "opencv-python-headless==4.11.0.86",


### PR DESCRIPTION
## Summary

Adds a `deploy.onnx.precision` option (`fp32` | `fp16`, default `fp32`) to the ONNX export stage.

- `fp32` exports the model exactly as before.
- `fp16` converts the export to half precision **internally, behind an fp32 graph boundary**: initializers and internal tensors become fp16, while graph inputs/outputs stay fp32 via cast layers inside the model. Engine I/O therefore keeps its dtype contract and consumers keep their fp32 buffers, whatever the export precision.

The exported ONNX is the single source of truth for an engine's numerics. The TensorRT stage builds strongly typed, as it always has, so the builder uses the dtypes the ONNX carries instead of assigning its own — picking a precision is a `deploy.onnx.precision` decision only, and there is deliberately no TensorRT-side typing knob.

Reduced-precision exports have to be built this way: the weakly typed precision-assignment pass would re-process the already-reduced tensors, and on one of our embedded targets it crashes on PTv3-shaped graphs regardless of builder settings. Consuming inference nodes must honor the export's dtypes too — in Autoware that is `trt_precision: strongly-typed` (autoware_universe counterpart PRs).

The conversion (in the new `autoware_ml/utils/onnx_precision.py`, wired into `scripts/deploy.py` after graph modifiers) handles three pitfalls of `onnxconverter-common` on these graphs:

- graph outputs that double as internal inputs (PTv3's `point_feat_0` feeds the next encoder stage): internal consumers are rewired to the pre-cast fp16 tensor, since the fp32 output cast must not re-enter the fp16 interior;
- pre-existing no-op `Cast(to=FLOAT)` nodes (e.g. the post-softmax `.to(query.dtype)` pattern) are retargeted to fp16 — except the boundary casts producing graph outputs — since a strongly typed parse rejects the mixed-precision consumers they would otherwise create;
- the op block list is empty, because the custom plugin ops negotiate their own precisions and support fp16 I/O natively.

Precisions that require calibration (int8) are explicitly out of scope.

## Related Issues

- autoware_universe counterparts: autowarefoundation/autoware_universe#13160 (strongly typed builds in `autoware_tensorrt_common`, merged), autowarefoundation/autoware_universe#13191 (names the precision value `"strongly-typed"`), autowarefoundation/autoware_universe#13159 (PTv3 adoption)
- Related optimization (independent): autowarefoundation/autoware_universe#13158

## Checklist

- [x] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [x] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

## Additional Notes

- The option is documented in `docs/user-guide/deployment.md` rather than in comments in `deploy.yaml`, per review.
- `deploy.onnx.precision` is typed as an `OnnxPrecision(StrEnum)` with `auto()` values, per review, so the accepted spellings and the config strings are the same thing.
- `pixi.lock` is regenerated with the repo-pinned pixi 0.66.0 (in docker, keeping the v6 format): `onnxconverter-common==1.16.0` is locked in the `default` and `dev` environments (+17 lines, nothing else re-solved). The dependency is required — it is not pulled in transitively.
- Models containing subgraphs (`If`/`Loop`/`Scan`) are refused with an explicit `NotImplementedError`: the cast fixups only handle the top-level graph, and no autoware-ml model uses subgraphs.
- Unit tests cover the precision option validation and the conversion pitfalls — including the dual-use-output rewiring and the fp32 boundary contract — on a minimal synthetic graph (`tests/utils/test_onnx_precision.py`). Full suite in the project image: **507 passed**, against 502 at the base commit — exactly the four new tests, nothing else moved. (The 2 collection errors in both runs are the `bev_pool` CUDA extension not being built in that workspace.)
- Note for whoever rebuilds the published image: `onnxconverter-common` is new in the lockfile, and `scripts/deploy.py` imports it unconditionally, so a container built from the previous lock fails on every deploy — including the default fp32 path — until the image is rebuilt.
- fp16 accuracy validation against the fp32 reference is pending; this PR is about producing deployable builds.

## Additional Log and Media

Verified with the PTv3 HuggingFace package: the converted encoder, seg3d head and det3d head keep fp32 graph I/O (`io dtypes = FLOAT/INT32/INT64`, 210/86/157 fp16 initializers) and build as strongly typed TensorRT engines through the unmodified PTv3 node buffers, on x86 and on the embedded target, where the weakly typed fp16 build crashes.
