### PR TITLE
fix: read a single NVIDIA driver version

### DIFF
--- a/ansible/roles/nvidia/tasks/main.yaml
+++ b/ansible/roles/nvidia/tasks/main.yaml
@@ -6,7 +6,12 @@
   ignore_errors: true
 
 - name: Get installed NVIDIA driver version
-  ansible.builtin.shell: nvidia-smi --query-gpu=driver_version --format=csv,noheader | cut -d'.' -f1
+  # nvidia-smi returns one row per GPU, but the driver version is host-wide.
+  ansible.builtin.shell:
+    cmd: >-
+      nvidia-smi --query-gpu=driver_version --format=csv,noheader
+      | head -n 1
+      | cut -d'.' -f1
   register: nvidia_installed_version
   changed_when: false
   failed_when: false


### PR DESCRIPTION
## Summary

Fix NVIDIA driver-version detection on multi-GPU systems.

When setting up Autoware-ML on a GPU cluster with multiple GPUs, `nvidia-smi` returns one driver-version value per GPU. The Ansible role compared this series of versions against a single predefined minimum version, causing the CUDA/NVIDIA driver check to fail even when the installed driver met the requirement.

This PR fixes the issue by reading only the first host-wide NVIDIA driver-version value returned by `nvidia-smi`.

## Related Issues

None.

## Checklist

- [x] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/main/contributing/contribution-overview/).
- [x] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/main/contributing/pull-request-guidelines/).

## Additional Notes

The NVIDIA driver version is host-wide, while `nvidia-smi` returns one row for each GPU. Selecting the first value prevents the multi-line result from causing the minimum-version comparison to fail.

## Additional Log and Media

The attached screenshot shows the installation failure on a multi-GPU system, where the detected driver version was incorrectly treated as multiple values.

<img width="1954" height="516" alt="Pasted image" src="https://github.com/user-attachments/assets/10cf8bc2-238e-4088-b812-664d5c010990" />
