### PR TITLE
chore: align python tooling with pixi and clarify installation docs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,6 +7,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install development tools via apt-get
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  coreutils \
   curl \
   gdb \
   gdbserver \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -46,7 +46,13 @@
           "bash": {
             "path": "/bin/bash"
           }
-        }
+        },
+        "python.analysis.languageServerMode": "full",
+        "python.analysis.indexing": true,
+        "python.analysis.extraPaths": [
+          "${workspaceFolder}"
+        ],
+        "python.terminal.activateEnvironment": true
       },
       "extensions": [
         "charliermarsh.ruff",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -53,7 +53,12 @@
     "node_modules",
     "site"
   ],
-  "python.defaultInterpreterPath": "/opt/conda/bin/python",
+  "python.defaultInterpreterPath": "/opt/pixi/envs/autoware-ml-3316095427567709615/envs/dev/bin/python",
+  "python.analysis.languageServerMode": "full",
+  "python.analysis.indexing": true,
+  "python.analysis.extraPaths": [
+    "${workspaceFolder}"
+  ],
   "python-envs.defaultEnvManager": "ms-python.python:system",
   "remote.autoForwardPorts": false,
   "ruff.lineLength": 100,

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -45,24 +45,32 @@ Autoware-ML runs well in a Docker container with GPU support. We encourage you t
     # Remove apt-installed Ansible (In Ubuntu 22.04, the Ansible version is old)
     sudo apt purge ansible
 
-    # Install pip
+    # Install Python 3.11 and pip
     sudo apt -y update
-    sudo apt -y install python3-pip
+    sudo apt -y install python3.11 python3.11-venv python3-pip
 
     # Install Ansible (if not already installed)
-    sudo python3 -m pip install ansible==10.7.0
+    sudo python3.11 -m pip install ansible==10.7.0
 
     # Install required Ansible collections
     cd ~/autoware-ml
     ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
 
-    # Pick one of the two playbooks below depending on your workflow:
-    # Docker-based development host
-    ansible-playbook ansible/playbooks/setup_docker_host.yaml -K
-
-    # Local pixi development host
-    ansible-playbook ansible/playbooks/setup_local_host.yaml -K
     ```
+
+    Then run the playbook that matches your workflow:
+
+    === "Docker-based development host"
+
+        ```bash
+        ansible-playbook ansible/playbooks/setup_docker_host.yaml -K
+        ```
+
+    === "Local pixi development host"
+
+        ```bash
+        ansible-playbook ansible/playbooks/setup_local_host.yaml -K
+        ```
 
 === "Manual Setup"
 


### PR DESCRIPTION
## Summary

Aligns the development environment's Python tooling with the pixi environment that the
image actually ships, and clarifies the corresponding host-setup documentation.

## Changes

**Dev environment**

- `.vscode/settings.json`: `python.defaultInterpreterPath` pointed at `/opt/conda/bin/python`,
  which no longer exists in the image. Repointed at the pixi `dev` environment so the
  Python extension resolves an interpreter out of the box.
- Enabled `python.analysis.languageServerMode: full` and `python.analysis.indexing`, and
  added the workspace root to `python.analysis.extraPaths`, so Pylance resolves
  first-party `autoware_ml` imports.
- Mirrored the same analysis settings into `.devcontainer/devcontainer.json` so the
  devcontainer and the local workspace behave the same way.
- `.devcontainer/Dockerfile`: added `coreutils`.

**Installation docs**

- Documented the Python 3.11 requirement explicitly. The version is already pinned in
  `pyproject.toml`, but the host-setup instructions previously installed the distro
  default `python3-pip` and ran `python3 -m pip`, which silently produces an Ansible
  install on the wrong interpreter on Ubuntu 22.04.
- Split the two Ansible playbook invocations (`setup_docker_host.yaml` and
  `setup_local_host.yaml`) into their own content tabs, so the choice reads as a choice
  instead of two commented-out lines in one block.

## Testing

All checks were run inside the Autoware-ML container (`./docker/container.sh --exec`):

- `pre-commit run -a --config .pre-commit-config.yaml` — all hooks pass, no files
  modified (includes `yamllint`, `markdownlint`, `clang-format`, `Hadolint`).
- `pytest autoware_ml/tests/ -q` — 526 passed.
- Working tree clean.

CSpell and clang-tidy cannot run locally (no Node in the image; no compile database),
so they are left to CI. This change touches no C, C++, or CUDA sources, so clang-tidy
has nothing to analyse here.

## Notes

The NVIDIA driver-version fix is intentionally **not** part of this PR — it is owned by
#90. An earlier revision of this branch carried a duplicate of that commit; it has been
dropped so the two PRs do not overlap.
