### PR TITLE
refactor(transforms): resolve raw names at load and drop use_valid_flag

### DIFF
--- a/autoware_ml/configs/datasets/nuscenes/detection3d.yaml
+++ b/autoware_ml/configs/datasets/nuscenes/detection3d.yaml
@@ -26,7 +26,6 @@ name_mapping:
   barrier: barrier
 # merge_objects: [[truck, [truck, trailer]]]  # TODO: support objects merge for nuscenes
 filter_attributes: []
-use_valid_flag: true
 eval_class_range:
   car: 50.0
   truck: 50.0

--- a/autoware_ml/configs/datasets/t4dataset/detection3d.yaml
+++ b/autoware_ml/configs/datasets/t4dataset/detection3d.yaml
@@ -77,7 +77,6 @@ filter_attributes:
   - [motorcycle, cycle_state.without_rider]
   - [motorcycle, motorcycle_state.without_rider]
 merge_objects: [[truck, [truck, trailer]]]
-use_valid_flag: true
 train_min_points_near: 3
 train_min_points_far: 2
 eval_class_range:

--- a/autoware_ml/configs/tasks/detection3d/bevfusion/camera_lidar_voxel0075_second_secfpn_54m_nuscenes.yaml
+++ b/autoware_ml/configs/tasks/detection3d/bevfusion/camera_lidar_voxel0075_second_secfpn_54m_nuscenes.yaml
@@ -73,6 +73,9 @@ datamodule:
         point_cloud_range: ${point_cloud_range}
       - _target_: autoware_ml.transforms.boxes3d.filters.ObjectRangeFilter
         point_cloud_range: ${point_cloud_range}
+      - _target_: autoware_ml.transforms.boxes3d.filters.ObjectRangeMinPointsFilter
+        range_radius: [0.0, 60.0]
+        min_num_points: 1
       - _target_: autoware_ml.transforms.camera.masking.GridMask
         p: 0.0
       - _target_: autoware_ml.transforms.point_cloud.sampling.PointShuffle

--- a/autoware_ml/configs/tasks/detection3d/bevfusion/camera_lidar_voxel0170_second_secfpn_120m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/bevfusion/camera_lidar_voxel0170_second_secfpn_120m_t4dataset_j6gen2.yaml
@@ -52,7 +52,6 @@ datamodule:
       - _target_: autoware_ml.transforms.boxes3d.loading.LoadAnnotations3D
         name_mapping: ${dataset.detection3d.name_mapping}
         filter_attributes: ${dataset.detection3d.filter_attributes}
-        use_valid_flag: ${dataset.detection3d.use_valid_flag}
       - _target_: autoware_ml.transforms.camera.loading.LoadMultiViewImagesFromFiles
       - _target_: autoware_ml.transforms.point_cloud.sweeps.LoadPointsFromMultiSweeps
         sweeps_num: 2
@@ -95,7 +94,6 @@ datamodule:
       - _target_: autoware_ml.transforms.boxes3d.loading.LoadAnnotations3D
         name_mapping: ${dataset.detection3d.name_mapping}
         filter_attributes: ${dataset.detection3d.filter_attributes}
-        use_valid_flag: ${dataset.detection3d.use_valid_flag}
       - _target_: autoware_ml.transforms.camera.loading.LoadMultiViewImagesFromFiles
       - _target_: autoware_ml.transforms.point_cloud.sweeps.LoadPointsFromMultiSweeps
         sweeps_num: 2

--- a/autoware_ml/configs/tasks/detection3d/bevfusion/lidar_voxel0075_second_secfpn_54m_nuscenes.yaml
+++ b/autoware_ml/configs/tasks/detection3d/bevfusion/lidar_voxel0075_second_secfpn_54m_nuscenes.yaml
@@ -56,6 +56,9 @@ datamodule:
         point_cloud_range: ${point_cloud_range}
       - _target_: autoware_ml.transforms.boxes3d.filters.ObjectRangeFilter
         point_cloud_range: ${point_cloud_range}
+      - _target_: autoware_ml.transforms.boxes3d.filters.ObjectRangeMinPointsFilter
+        range_radius: [0.0, 60.0]
+        min_num_points: 1
       - _target_: autoware_ml.transforms.point_cloud.sampling.PointShuffle
   val_transforms:
     _target_: autoware_ml.transforms.base.TransformsCompose

--- a/autoware_ml/configs/tasks/detection3d/bevfusion/lidar_voxel0170_second_secfpn_120m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/bevfusion/lidar_voxel0170_second_secfpn_120m_t4dataset_j6gen2.yaml
@@ -24,7 +24,6 @@ datamodule:
   class_names: ${dataset.detection3d.class_names}
   name_mapping: ${dataset.detection3d.name_mapping}
   filter_attributes: ${dataset.detection3d.filter_attributes}
-  use_valid_flag: ${dataset.detection3d.use_valid_flag}
   train_dataloader_cfg:
     batch_size: ${batch_size}
     num_workers: ${num_workers}
@@ -44,7 +43,6 @@ datamodule:
       - _target_: autoware_ml.transforms.boxes3d.loading.LoadAnnotations3D
         name_mapping: ${dataset.detection3d.name_mapping}
         filter_attributes: ${dataset.detection3d.filter_attributes}
-        use_valid_flag: ${dataset.detection3d.use_valid_flag}
       - _target_: autoware_ml.transforms.point_cloud.sweeps.LoadPointsFromMultiSweeps
         sweeps_num: 2
         load_dim: 5
@@ -80,7 +78,6 @@ datamodule:
       - _target_: autoware_ml.transforms.boxes3d.loading.LoadAnnotations3D
         name_mapping: ${dataset.detection3d.name_mapping}
         filter_attributes: ${dataset.detection3d.filter_attributes}
-        use_valid_flag: ${dataset.detection3d.use_valid_flag}
       - _target_: autoware_ml.transforms.point_cloud.sweeps.LoadPointsFromMultiSweeps
         sweeps_num: 2
         load_dim: 5

--- a/autoware_ml/configs/tasks/detection3d/centerpoint/voxel020_second_secfpn_51m_nuscenes.yaml
+++ b/autoware_ml/configs/tasks/detection3d/centerpoint/voxel020_second_secfpn_51m_nuscenes.yaml
@@ -64,6 +64,9 @@ datamodule:
         point_cloud_range: ${point_cloud_range}
       - _target_: autoware_ml.transforms.boxes3d.filters.ObjectRangeFilter
         point_cloud_range: ${point_cloud_range}
+      - _target_: autoware_ml.transforms.boxes3d.filters.ObjectRangeMinPointsFilter
+        range_radius: [0.0, 60.0]
+        min_num_points: 1
       - _target_: autoware_ml.transforms.point_cloud.sampling.PointShuffle
   val_transforms:
     _target_: autoware_ml.transforms.base.TransformsCompose

--- a/autoware_ml/configs/tasks/detection3d/centerpoint/voxel024_second_secfpn_120m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/centerpoint/voxel024_second_secfpn_120m_t4dataset_j6gen2.yaml
@@ -33,7 +33,6 @@ datamodule:
   class_names: ${dataset.detection3d.class_names}
   name_mapping: ${dataset.detection3d.name_mapping}
   filter_attributes: ${dataset.detection3d.filter_attributes}
-  use_valid_flag: ${dataset.detection3d.use_valid_flag}
   train_dataloader_cfg:
     batch_size: ${batch_size}
     num_workers: ${num_workers}
@@ -53,7 +52,6 @@ datamodule:
       - _target_: autoware_ml.transforms.boxes3d.loading.LoadAnnotations3D
         name_mapping: ${dataset.detection3d.name_mapping}
         filter_attributes: ${dataset.detection3d.filter_attributes}
-        use_valid_flag: ${dataset.detection3d.use_valid_flag}
       - _target_: autoware_ml.transforms.point_cloud.sweeps.LoadPointsFromMultiSweeps
         sweeps_num: 2
         load_dim: 5
@@ -88,7 +86,6 @@ datamodule:
       - _target_: autoware_ml.transforms.boxes3d.loading.LoadAnnotations3D
         name_mapping: ${dataset.detection3d.name_mapping}
         filter_attributes: ${dataset.detection3d.filter_attributes}
-        use_valid_flag: ${dataset.detection3d.use_valid_flag}
       - _target_: autoware_ml.transforms.point_cloud.sweeps.LoadPointsFromMultiSweeps
         sweeps_num: 2
         load_dim: 5

--- a/autoware_ml/configs/tasks/detection3d/ptv3/voxel005_51m_nuscenes.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/voxel005_51m_nuscenes.yaml
@@ -40,7 +40,6 @@ datamodule:
       - _target_: autoware_ml.transforms.boxes3d.loading.LoadAnnotations3D
         name_mapping: ${dataset.detection3d.name_mapping}
         filter_attributes: ${dataset.detection3d.filter_attributes}
-        use_valid_flag: ${dataset.detection3d.use_valid_flag}
       - _target_: autoware_ml.transforms.point_cloud.sweeps.LoadPointsFromMultiSweeps
         sweeps_num: ${train_sweeps_num}
         load_dim: 5
@@ -72,6 +71,9 @@ datamodule:
         shift_range: [-0.02, 0.02]
       - _target_: autoware_ml.transforms.boxes3d.filters.ObjectRangeFilter
         point_cloud_range: ${point_cloud_range}
+      - _target_: autoware_ml.transforms.boxes3d.filters.ObjectRangeMinPointsFilter
+        range_radius: [0.0, 60.0]
+        min_num_points: 1
       - _target_: autoware_ml.transforms.point_cloud.sampling.GridSample
         grid_size: ${grid_size}
         point_cloud_range: ${point_cloud_range}
@@ -89,7 +91,6 @@ datamodule:
       - _target_: autoware_ml.transforms.boxes3d.loading.LoadAnnotations3D
         name_mapping: ${dataset.detection3d.name_mapping}
         filter_attributes: ${dataset.detection3d.filter_attributes}
-        use_valid_flag: ${dataset.detection3d.use_valid_flag}
       - _target_: autoware_ml.transforms.point_cloud.sweeps.LoadPointsFromMultiSweeps
         sweeps_num: ${val_sweeps_num}
         load_dim: 5

--- a/autoware_ml/configs/tasks/detection3d/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
@@ -18,7 +18,6 @@ num_proposals: 500
 datamodule:
   _target_: autoware_ml.datamodule.t4dataset.detection3d.T4Detection3DDataModule
   filter_attributes: ${dataset.detection3d.filter_attributes}
-  use_valid_flag: ${dataset.detection3d.use_valid_flag}
   train_transforms:
     _target_: autoware_ml.transforms.base.TransformsCompose
     pipeline:
@@ -28,7 +27,6 @@ datamodule:
       - _target_: autoware_ml.transforms.boxes3d.loading.LoadAnnotations3D
         name_mapping: ${dataset.detection3d.name_mapping}
         filter_attributes: ${dataset.detection3d.filter_attributes}
-        use_valid_flag: ${dataset.detection3d.use_valid_flag}
       - _target_: autoware_ml.transforms.point_cloud.sweeps.LoadPointsFromMultiSweeps
         sweeps_num: ${train_sweeps_num}
         load_dim: 5
@@ -86,7 +84,6 @@ datamodule:
       - _target_: autoware_ml.transforms.boxes3d.loading.LoadAnnotations3D
         name_mapping: ${dataset.detection3d.name_mapping}
         filter_attributes: ${dataset.detection3d.filter_attributes}
-        use_valid_flag: ${dataset.detection3d.use_valid_flag}
       - _target_: autoware_ml.transforms.point_cloud.sweeps.LoadPointsFromMultiSweeps
         sweeps_num: ${val_sweeps_num}
         load_dim: 5

--- a/autoware_ml/configs/tasks/detection3d/transfusion/voxel0075_second_secfpn_54m_nuscenes.yaml
+++ b/autoware_ml/configs/tasks/detection3d/transfusion/voxel0075_second_secfpn_54m_nuscenes.yaml
@@ -53,6 +53,9 @@ datamodule:
         point_cloud_range: ${point_cloud_range}
       - _target_: autoware_ml.transforms.boxes3d.filters.ObjectRangeFilter
         point_cloud_range: ${point_cloud_range}
+      - _target_: autoware_ml.transforms.boxes3d.filters.ObjectRangeMinPointsFilter
+        range_radius: [0.0, 60.0]
+        min_num_points: 1
       - _target_: autoware_ml.transforms.point_cloud.sampling.PointShuffle
   val_transforms:
     _target_: autoware_ml.transforms.base.TransformsCompose

--- a/autoware_ml/configs/tasks/detection3d/transfusion/voxel0170_second_secfpn_120m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/transfusion/voxel0170_second_secfpn_120m_t4dataset_j6gen2.yaml
@@ -23,7 +23,6 @@ datamodule:
   class_names: ${dataset.detection3d.class_names}
   name_mapping: ${dataset.detection3d.name_mapping}
   filter_attributes: ${dataset.detection3d.filter_attributes}
-  use_valid_flag: ${dataset.detection3d.use_valid_flag}
   train_dataloader_cfg:
     batch_size: ${batch_size}
     num_workers: ${num_workers}
@@ -43,7 +42,6 @@ datamodule:
       - _target_: autoware_ml.transforms.boxes3d.loading.LoadAnnotations3D
         name_mapping: ${dataset.detection3d.name_mapping}
         filter_attributes: ${dataset.detection3d.filter_attributes}
-        use_valid_flag: ${dataset.detection3d.use_valid_flag}
       - _target_: autoware_ml.transforms.point_cloud.sweeps.LoadPointsFromMultiSweeps
         sweeps_num: 2
         load_dim: 5
@@ -76,7 +74,6 @@ datamodule:
       - _target_: autoware_ml.transforms.boxes3d.loading.LoadAnnotations3D
         name_mapping: ${dataset.detection3d.name_mapping}
         filter_attributes: ${dataset.detection3d.filter_attributes}
-        use_valid_flag: ${dataset.detection3d.use_valid_flag}
       - _target_: autoware_ml.transforms.point_cloud.sweeps.LoadPointsFromMultiSweeps
         sweeps_num: 2
         load_dim: 5

--- a/autoware_ml/configs/tasks/multi/ptv3/voxel005_51m_nuscenes.yaml
+++ b/autoware_ml/configs/tasks/multi/ptv3/voxel005_51m_nuscenes.yaml
@@ -80,6 +80,9 @@ datamodule:
         shift_range: [-0.02, 0.02]
       - _target_: autoware_ml.transforms.boxes3d.filters.ObjectRangeFilter
         point_cloud_range: ${point_cloud_range}
+      - _target_: autoware_ml.transforms.boxes3d.filters.ObjectRangeMinPointsFilter
+        range_radius: [0.0, 60.0]
+        min_num_points: 1
       - _target_: autoware_ml.transforms.common.copying.Copy
         keys_dict: { segment: origin_segment }
       - _target_: autoware_ml.transforms.point_cloud.sampling.GridSample

--- a/autoware_ml/configs/tasks/multi/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/multi/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
@@ -22,7 +22,6 @@ num_workers: 8
 datamodule:
   _target_: autoware_ml.datamodule.t4dataset.segdet.T4SegmentationDetection3DDataModule
   filter_attributes: ${dataset.detection3d.filter_attributes}
-  use_valid_flag: false
   train_frame_sampling:
     repeat_sampling_factor: 0.30
     object_bev_range: [-122.88, -122.88, 122.88, 122.88]
@@ -50,7 +49,6 @@ datamodule:
       - _target_: autoware_ml.transforms.boxes3d.loading.LoadAnnotations3D
         name_mapping: ${dataset.detection3d.name_mapping}
         filter_attributes: ${dataset.detection3d.filter_attributes}
-        use_valid_flag: false
       - _target_: autoware_ml.transforms.segmentation3d.loading.LoadSegAnnotations3D
         class_mapping: ${segmentation_class_mapping}
         ignore_index: ${dataset.segmentation3d.ignore_index}
@@ -114,7 +112,6 @@ datamodule:
       - _target_: autoware_ml.transforms.boxes3d.loading.LoadAnnotations3D
         name_mapping: ${dataset.detection3d.name_mapping}
         filter_attributes: ${dataset.detection3d.filter_attributes}
-        use_valid_flag: false
       - _target_: autoware_ml.transforms.segmentation3d.loading.LoadSegAnnotations3D
         class_mapping: ${segmentation_class_mapping}
         ignore_index: ${dataset.segmentation3d.ignore_index}

--- a/autoware_ml/datamodule/t4dataset/detection3d.py
+++ b/autoware_ml/datamodule/t4dataset/detection3d.py
@@ -60,7 +60,14 @@ class FrameSamplingConfig:
 def coerce_frame_sampling(
     cfg: FrameSamplingConfig | Mapping[str, Any] | None,
 ) -> FrameSamplingConfig | None:
-    """Normalize frame-sampling settings to ``FrameSamplingConfig``."""
+    """Normalize frame-sampling settings to ``FrameSamplingConfig``.
+
+    Args:
+        cfg: Frame-sampling settings as a dataclass, a mapping, or ``None``.
+
+    Returns:
+        The settings as ``FrameSamplingConfig``, or ``None`` when disabled.
+    """
     if cfg is None:
         return None
     if isinstance(cfg, FrameSamplingConfig):
@@ -79,9 +86,19 @@ def compute_frame_sampling_weights(
     name_mapping: Mapping[str, str],
     frame_sampling: FrameSamplingConfig | None,
     filter_attributes: list[list[str]] | None = None,
-    use_valid_flag: bool = True,
 ) -> list[float]:
-    """Compute repeat-factor sampling weights for T4 detection samples."""
+    """Compute repeat-factor sampling weights for T4 detection samples.
+
+    Args:
+        data_infos: Annotation records of the split.
+        class_names: Detector class names in label order.
+        name_mapping: Raw category to detector class mapping.
+        frame_sampling: Repeat-factor settings, or ``None`` to disable weighting.
+        filter_attributes: Class and attribute name pairs excluded from class counting.
+
+    Returns:
+        One sampling weight per sample, uniform when weighting is disabled.
+    """
     if frame_sampling is None:
         return [1.0] * len(data_infos)
     normalized_filter_attributes = normalize_filter_attributes(filter_attributes)
@@ -98,7 +115,6 @@ def compute_frame_sampling_weights(
             name_mapping,
             frame_sampling,
             normalized_filter_attributes,
-            use_valid_flag,
         )
         frame_categories.append(categories)
         for category, count in categories.items():
@@ -140,7 +156,6 @@ def _sample_sampling_categories(
     name_mapping: Mapping[str, str],
     frame_sampling: FrameSamplingConfig,
     filter_attributes: frozenset[tuple[str, str]],
-    use_valid_flag: bool,
 ) -> dict[str, int]:
     """Return sampling category counts for one frame."""
     categories = {*class_names, frame_sampling.low_pedestrian_category_name}
@@ -153,12 +168,15 @@ def _sample_sampling_categories(
             name_mapping=name_mapping,
             label_to_category=sample.get("label_to_category"),
             filter_attributes=filter_attributes,
-            use_valid_flag=use_valid_flag,
         )
         if mapped_name is None:
             continue
         box = instance.get("bbox_3d")
         if box is None or not box_is_physical(box, sanitize_velocity(instance.get("velocity"))):
+            continue
+        # A box with no lidar points gives no supervision (the point-count train
+        # filters drop it), so it must not inflate the frame's sampling weight.
+        if int(instance.get("num_lidar_pts", 0)) <= 0:
             continue
         if not _box_center_in_bev_range(box, frame_sampling.object_bev_range):
             continue
@@ -204,7 +222,6 @@ class T4Detection3DDataset(Dataset):
         class_names: list[str],
         name_mapping: Mapping[str, str],
         filter_attributes: list[list[str]] | None = None,
-        use_valid_flag: bool = True,
         frame_sampling: FrameSamplingConfig | None = None,
         dataset_transforms: TransformsCompose | None = None,
     ) -> None:
@@ -216,7 +233,6 @@ class T4Detection3DDataset(Dataset):
             class_names: Ordered detector class names.
             name_mapping: Mapping from dataset labels to detector labels.
             filter_attributes: Raw class-attribute pairs excluded from detection targets.
-            use_valid_flag: Whether ``bbox_3d_isvalid`` excludes sampled boxes.
             frame_sampling: Optional repeat-factor frame sampling settings.
             dataset_transforms: Optional dataset transform pipeline.
         """
@@ -235,7 +251,6 @@ class T4Detection3DDataset(Dataset):
             self.name_mapping,
             self.frame_sampling,
             filter_attributes=filter_attributes,
-            use_valid_flag=use_valid_flag,
         )
         # Serialize last: frame_weights above must run on the live list.
         self.data_infos = SerializedSampleList(data_infos)
@@ -286,7 +301,6 @@ class T4Detection3DDataModule(DataModule):
         class_names: list[str],
         name_mapping: Mapping[str, str],
         filter_attributes: list[list[str]] | None = None,
-        use_valid_flag: bool = True,
         train_frame_sampling: FrameSamplingConfig | Mapping[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
@@ -300,7 +314,6 @@ class T4Detection3DDataModule(DataModule):
             class_names: Ordered detector class names.
             name_mapping: Mapping from dataset labels to detector labels.
             filter_attributes: Raw class-attribute pairs excluded from detection targets.
-            use_valid_flag: Whether ``bbox_3d_isvalid`` excludes sampled train boxes.
             train_frame_sampling: Optional repeat-factor frame sampling
                 settings applied only to the training split.
             **kwargs: Additional base datamodule configuration.
@@ -310,10 +323,17 @@ class T4Detection3DDataModule(DataModule):
         self.class_names = class_names
         self.name_mapping = name_mapping
         self.filter_attributes = filter_attributes
-        self.use_valid_flag = use_valid_flag
         self.train_frame_sampling = coerce_frame_sampling(train_frame_sampling)
 
         def resolve_ann_file(ann_file: str) -> str:
+            """Return ``ann_file`` absolute, joined to the data root when relative.
+
+            Args:
+                ann_file: Annotation file path, absolute or relative to the data root.
+
+            Returns:
+                The absolute annotation file path.
+            """
             return ann_file if os.path.isabs(ann_file) else os.path.join(data_root, ann_file)
 
         self.ann_files = {
@@ -341,7 +361,6 @@ class T4Detection3DDataModule(DataModule):
             class_names=self.class_names,
             name_mapping=self.name_mapping,
             filter_attributes=self.filter_attributes,
-            use_valid_flag=self.use_valid_flag,
             frame_sampling=self.train_frame_sampling if split == "train" else None,
             dataset_transforms=dataset_transforms,
         )

--- a/autoware_ml/datamodule/t4dataset/segdet.py
+++ b/autoware_ml/datamodule/t4dataset/segdet.py
@@ -58,17 +58,25 @@ class T4SegmentationDetection3DDataset(Dataset):
         class_names: list[str],
         name_mapping: Mapping[str, str],
         filter_attributes: list[list[str]] | None = None,
-        use_valid_flag: bool = False,
         frame_sampling: FrameSamplingConfig | None = None,
         dataset_transforms: TransformsCompose | None = None,
     ) -> None:
-        """Initialize the combined T4 segmentation+detection dataset."""
+        """Initialize the combined T4 segmentation+detection dataset.
+
+        Args:
+            data_root: Dataset root directory.
+            ann_sources: Annotation sources merged into one sample list.
+            class_names: Detector class names in label order.
+            name_mapping: Raw category to detector class mapping.
+            filter_attributes: Class and attribute name pairs excluded from detection.
+            frame_sampling: Repeat-factor settings, or ``None`` to disable weighting.
+            dataset_transforms: Optional dataset transform pipeline.
+        """
         super().__init__(dataset_transforms=dataset_transforms)
         self.data_root = data_root
         self.class_names = class_names
         self.name_mapping = name_mapping
         self.filter_attributes = normalize_filter_attributes(filter_attributes)
-        self.use_valid_flag = use_valid_flag
         self.frame_sampling = frame_sampling
 
         data_infos: list[dict[str, Any]] = []
@@ -81,7 +89,6 @@ class T4SegmentationDetection3DDataset(Dataset):
             self.name_mapping,
             self.frame_sampling,
             self.filter_attributes,
-            self.use_valid_flag,
         )
         # Serialize last: frame_weights above must run on the live list.
         self.data_infos = SerializedSampleList(data_infos)
@@ -125,7 +132,14 @@ class T4SegmentationDetection3DDataset(Dataset):
         return len(self.data_infos)
 
     def get_data_info(self, index: int) -> dict[str, Any]:
-        """Build one combined metadata record consumed by the transform pipeline."""
+        """Build one combined metadata record consumed by the transform pipeline.
+
+        Args:
+            index: Dataset index.
+
+        Returns:
+            Metadata dictionary with detection and segmentation fields.
+        """
         sample = self.data_infos[index]
         return {
             "instances": sample.get("instances", []),
@@ -155,7 +169,6 @@ class T4SegmentationDetection3DDataModule(DataModule):
         class_names: list[str],
         name_mapping: Mapping[str, str],
         filter_attributes: list[list[str]] | None = None,
-        use_valid_flag: bool = False,
         train_frame_sampling: FrameSamplingConfig | Mapping[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
@@ -173,7 +186,6 @@ class T4SegmentationDetection3DDataModule(DataModule):
             class_names: Ordered detector class names.
             name_mapping: Raw-name to detector-class mapping.
             filter_attributes: Attribute pairs excluded from annotations.
-            use_valid_flag: Whether per-instance validity flags filter boxes.
             train_frame_sampling: Repeat-factor frame sampling configuration.
             **kwargs: Keyword arguments forwarded to :class:`DataModule`.
         """
@@ -182,7 +194,6 @@ class T4SegmentationDetection3DDataModule(DataModule):
         self.class_names = class_names
         self.name_mapping = name_mapping
         self.filter_attributes = normalize_filter_attributes(filter_attributes)
-        self.use_valid_flag = use_valid_flag
         self.train_frame_sampling = coerce_frame_sampling(train_frame_sampling)
 
         self.ann_sources = {
@@ -202,7 +213,6 @@ class T4SegmentationDetection3DDataModule(DataModule):
             class_names=self.class_names,
             name_mapping=self.name_mapping,
             filter_attributes=self.filter_attributes,
-            use_valid_flag=self.use_valid_flag,
             frame_sampling=self.train_frame_sampling if split == "train" else None,
             dataset_transforms=dataset_transforms,
         )

--- a/autoware_ml/tests/datamodule/test_detection3d.py
+++ b/autoware_ml/tests/datamodule/test_detection3d.py
@@ -72,10 +72,13 @@ class TestT4Detection3DDataset:
         names = output["gt_names"]
         num_points = output["gt_num_points"]
 
-        assert boxes.shape == (1, 9)
-        assert labels.tolist() == [0]
-        assert names.tolist() == ["car"]
-        assert num_points.tolist() == [12]
+        # An invalid 0-point box reaches eval and is filtered there by
+        # min_num_points, so the loader keeps both mapped instances and carries
+        # the point count through for the occlusion split.
+        assert boxes.shape == (2, 9)
+        assert labels.tolist() == [0, 2]
+        assert names.tolist() == ["car", "pedestrian"]
+        assert num_points.tolist() == [12, 0]
         assert np.allclose(boxes[0, -2:], np.array([0.1, 0.0], dtype=np.float32))
 
     def test_get_data_info_exposes_metadata_for_loader_pipeline(self, tmp_path) -> None:
@@ -164,6 +167,43 @@ class TestT4Detection3DDataset:
 
         assert dataset.frame_weights[5] > dataset.frame_weights[0]
         assert np.isclose(dataset.frame_weights[5], 42**0.25)
+
+    def test_frame_sampling_weights_skip_boxes_without_points(self) -> None:
+        # A rare-class box with no lidar points gives no supervision, so it must
+        # not earn its frame a repeat-factor boost.
+        def frame(token: str, name: str, num_points: int) -> dict:
+            return {
+                "token": token,
+                "instances": [
+                    {
+                        "bbox_3d_isvalid": True,
+                        "gt_nusc_name": "car",
+                        "bbox_3d": [0.0, 0.0, 0.0, 4.0, 1.8, 1.5, 0.0],
+                        "num_lidar_pts": 10,
+                    },
+                    {
+                        "bbox_3d_isvalid": True,
+                        "gt_nusc_name": name,
+                        "bbox_3d": [1.0, 1.0, 0.0, 0.6, 0.6, 1.2, 0.0],
+                        "num_lidar_pts": num_points,
+                    },
+                ],
+            }
+
+        frames = [frame(f"car_{index}", "car", 10) for index in range(5)]
+        frames.append(frame("ped_zero", "pedestrian", 0))
+        weights = compute_frame_sampling_weights(
+            frames,
+            ["car", "pedestrian"],
+            {"car": "car", "pedestrian": "pedestrian"},
+            FrameSamplingConfig(
+                repeat_sampling_factor=1.0,
+                object_bev_range=[-50.0, -50.0, 50.0, 50.0],
+                low_pedestrian_height_threshold=0.0,
+                low_pedestrian_bev_range=[-50.0, -50.0, 50.0, 50.0],
+            ),
+        )
+        assert weights == [1.0] * len(frames)
 
     def test_frame_sampling_weights_exclude_filtered_attributes(self) -> None:
         data_infos = [

--- a/autoware_ml/tests/transforms/test_boxes3d.py
+++ b/autoware_ml/tests/transforms/test_boxes3d.py
@@ -225,7 +225,10 @@ def test_load_annotations3d_drops_physically_invalid_instances() -> None:
     assert np.allclose(output["gt_boxes"][2, 7:], [0.0, 0.0])  # nan velocity zeroed, box kept
 
 
-def test_load_annotations3d_preserves_ignored_bbox_label() -> None:
+def test_load_annotations3d_prefers_raw_name_over_stale_bbox_label() -> None:
+    # A stale bbox_label_3d (here -1, "unclassed" under the file's older taxonomy)
+    # must not override the raw gt_nusc_name: the config's name_mapping decides the
+    # class, so the box is kept and classified from its raw name.
     sample = {
         "class_names": ["bicycle"],
         "label_to_category": {5: "bicycle"},
@@ -241,27 +244,30 @@ def test_load_annotations3d_preserves_ignored_bbox_label() -> None:
 
     output = LoadAnnotations3D(name_mapping={"bicycle": "bicycle"})(sample)
 
-    assert output["gt_boxes"].shape == (0, 9)
+    assert output["gt_boxes"].shape == (1, 9)
+    assert output["gt_names"].tolist() == ["bicycle"]
 
 
-def test_load_annotations3d_can_match_awml_validity_policy() -> None:
+def test_load_annotations3d_ignores_validity_flag() -> None:
+    # bbox_3d_isvalid is not a load-time filter: low-point filtering is the
+    # point-count filters' job (min_num_points), so an "invalid" (0-lidar-point)
+    # box is loaded and left for the point filter to drop.
     sample = {
         "class_names": ["car"],
         "instances": [
             {
                 "bbox_3d": [1.0, 2.0, 3.0, 2.0, 1.0, 1.5, 0.0],
                 "gt_nusc_name": "car",
-                "num_lidar_pts": 10,
+                "num_lidar_pts": 0,
                 "bbox_3d_isvalid": False,
             }
         ],
     }
 
-    default_output = LoadAnnotations3D()(sample.copy())
-    awml_output = LoadAnnotations3D(use_valid_flag=False)(sample.copy())
+    output = LoadAnnotations3D()(sample.copy())
 
-    assert default_output["gt_boxes"].shape == (0, 9)
-    assert awml_output["gt_boxes"].shape == (1, 9)
+    assert output["gt_boxes"].shape == (1, 9)
+    assert output["gt_num_points"].tolist() == [0]
 
 
 def test_load_annotations3d_filters_raw_class_attributes() -> None:
@@ -300,7 +306,10 @@ def test_normalize_filter_attributes_rejects_invalid_entries() -> None:
         normalize_filter_attributes(["bicycle"])
 
 
-def test_load_annotations3d_rejects_disagreeing_source_label() -> None:
+def test_load_annotations3d_prefers_raw_name_over_source_label() -> None:
+    # When gt_nusc_name and a pre-baked bbox_label_3d disagree (e.g. the file's
+    # class table predates the configured taxonomy), the raw name is authoritative
+    # and the pre-baked integer is ignored, no error is raised.
     sample = {
         "class_names": ["car", "pedestrian"],
         "label_to_category": {0: "car"},
@@ -314,7 +323,9 @@ def test_load_annotations3d_rejects_disagreeing_source_label() -> None:
         ],
     }
 
-    with pytest.raises(ValueError, match="Annotation label disagreement"):
-        LoadAnnotations3D(
-            name_mapping={"car": "car", "pedestrian": "pedestrian"},
-        )(sample)
+    output = LoadAnnotations3D(
+        name_mapping={"car": "car", "pedestrian": "pedestrian"},
+    )(sample)
+
+    assert output["gt_names"].tolist() == ["pedestrian"]
+    assert output["gt_labels"].tolist() == [1]

--- a/autoware_ml/transforms/boxes3d/annotations.py
+++ b/autoware_ml/transforms/boxes3d/annotations.py
@@ -30,7 +30,14 @@ MAX_ABSOLUTE_SPEED = 150.0
 
 
 def sanitize_velocity(velocity: Sequence[float] | None) -> list[float]:
-    """Return the ground-plane velocity with non-finite components zeroed."""
+    """Return the ground-plane velocity with non-finite components zeroed.
+
+    Args:
+        velocity: Ground-plane ``[vx, vy]``, or ``None`` for a static annotation.
+
+    Returns:
+        The sanitized ``[vx, vy]`` list.
+    """
     if velocity is None:
         return [0.0, 0.0]
     return [0.0 if not np.isfinite(v) else float(v) for v in velocity]
@@ -51,6 +58,9 @@ def box_is_physical(box: Sequence[float], velocity: Sequence[float]) -> bool:
         velocity: Ground-plane ``[vx, vy]``, sanitized via
             :func:`sanitize_velocity` so non-finite components never reach
             the drop decision.
+
+    Returns:
+        Whether the annotation is trainable.
     """
     values = np.array([*box, *velocity], dtype=np.float32)
     return bool(
@@ -63,7 +73,14 @@ def box_is_physical(box: Sequence[float], velocity: Sequence[float]) -> bool:
 def normalize_filter_attributes(
     filter_attributes: Iterable[Sequence[str]] | None,
 ) -> FilterAttributeSet:
-    """Normalize configured class-attribute exclusions for repeated lookup."""
+    """Normalize configured class-attribute exclusions for repeated lookup.
+
+    Args:
+        filter_attributes: Class and attribute name pairs, or ``None`` for none.
+
+    Returns:
+        The exclusions as a frozenset of ``(class, attribute)`` tuples.
+    """
     if filter_attributes is None:
         return frozenset()
 
@@ -91,34 +108,44 @@ def resolve_detection_class(
     name_mapping: Mapping[str, str | None] | None,
     label_to_category: Mapping[int, str] | None = None,
     filter_attributes: Collection[tuple[str, str]] | None = None,
-    use_valid_flag: bool = True,
 ) -> str | None:
-    """Resolve one stored instance into a detector class or reject it."""
-    if "bbox_label_3d" in instance and int(instance["bbox_label_3d"]) < 0:
-        return None
-    if use_valid_flag and not bool(instance.get("bbox_3d_isvalid", True)):
-        return None
+    """Resolve one stored instance into a detector class or reject it.
 
+    The raw annotation category (``gt_nusc_name``) together with the configured
+    ``name_mapping`` is the single source of truth for the class: the config
+    decides the taxonomy, the annotation file only delivers raw categories. The
+    pre-computed ``bbox_label_3d`` integer (which indexes the file's own,
+    possibly older, class table) is consulted *only* as a fallback when no raw
+    category name is recorded. This way changing the configured class set never
+    requires regenerating the info files: categories the current model does not
+    train are dropped by ``name_mapping``/``class_names``, and categories a file
+    predates are still picked up from their raw name.
+
+    Low-point boxes are not filtered here, that is the job of the point-count
+    filters (``min_num_points`` at train time, the metric suite at eval), which
+    subsume the lidar-point validity flag.
+
+    Args:
+        instance: Stored annotation instance.
+        class_names: Detector class names.
+        name_mapping: Raw category to detector class mapping.
+        label_to_category: Label index to raw category, from the file's metainfo.
+        filter_attributes: Normalized class and attribute exclusions.
+
+    Returns:
+        The detector class name, or ``None`` when the instance is rejected.
+    """
     raw_name = instance.get("gt_nusc_name")
-    stored_name = _resolve_stored_name(instance, label_to_category)
     if raw_name is None:
-        raw_name = stored_name
+        # Older converters store only the integer label, decode it through the
+        # annotation file's own class table (a negative label is unclassed).
+        raw_name = _resolve_stored_name(instance, label_to_category)
     if raw_name is None:
         return None
 
     raw_name = str(raw_name)
     mapped_name = _map_name(raw_name, name_mapping)
-    if stored_name is not None:
-        mapped_stored_name = _map_name(stored_name, name_mapping)
-        if mapped_name != mapped_stored_name:
-            raise ValueError(
-                "Annotation label disagreement: "
-                f"gt_nusc_name={raw_name!r} maps to {mapped_name!r}, while "
-                f"bbox_label_3d maps to source class {stored_name!r} and target "
-                f"{mapped_stored_name!r}."
-            )
-
-    if mapped_name not in class_names:
+    if mapped_name is None or mapped_name not in class_names:
         return None
     if _has_filtered_attribute(instance, raw_name, filter_attributes):
         return None
@@ -129,10 +156,16 @@ def _resolve_stored_name(
     instance: Mapping[str, Any],
     label_to_category: Mapping[int, str] | None,
 ) -> str | None:
-    """Decode ``bbox_label_3d`` through the annotation file's class table."""
+    """Decode ``bbox_label_3d`` through the annotation file's class table.
+
+    A negative label marks a box the annotation file assigned to no class; it
+    resolves to ``None`` (dropped) rather than raising.
+    """
     if "bbox_label_3d" not in instance or label_to_category is None:
         return None
     label = int(instance["bbox_label_3d"])
+    if label < 0:
+        return None
     if label not in label_to_category:
         raise ValueError(f"bbox_label_3d={label} is absent from the annotation class table.")
     return str(label_to_category[label])

--- a/autoware_ml/transforms/boxes3d/loading.py
+++ b/autoware_ml/transforms/boxes3d/loading.py
@@ -66,7 +66,6 @@ class LoadAnnotations3D(BaseTransform):
         *,
         name_mapping: Mapping[str, str | None] | None = None,
         filter_attributes: list[list[str]] | None = None,
-        use_valid_flag: bool = True,
     ) -> None:
         """Initialize the LoadAnnotations3D transform.
 
@@ -74,11 +73,9 @@ class LoadAnnotations3D(BaseTransform):
             name_mapping: Optional raw-to-canonical class-name mapping. Values set
                 to ``None`` drop the corresponding raw class.
             filter_attributes: Attribute groups used to filter raw annotations.
-            use_valid_flag: Whether to honor the raw ``bbox_3d_isvalid`` flag.
         """
         self.name_mapping = dict(name_mapping) if name_mapping is not None else None
         self.filter_attributes = normalize_filter_attributes(filter_attributes)
-        self.use_valid_flag = use_valid_flag
         self._validated_class_names: set[tuple[str, ...]] = set()
 
     def apply_defaults(self, input_dict: dict[str, Any]) -> None:
@@ -112,7 +109,6 @@ class LoadAnnotations3D(BaseTransform):
                 name_mapping=self.name_mapping,
                 label_to_category=input_dict.get("label_to_category"),
                 filter_attributes=self.filter_attributes,
-                use_valid_flag=self.use_valid_flag,
             )
             if canonical is None:
                 continue


### PR DESCRIPTION
## Summary

Annotation loading resolves detector classes from raw dataset names at load time and no longer consults the pre-baked validity flag.

- `resolve_detection_class` maps each instance from its raw name through `name_mapping`, decoding older info files that store only an integer label via the file's own class table.
- `use_valid_flag` is removed end to end (annotation transforms, both T4 datamodules, task configs). An invalid or 0-lidar-point GT box is loaded and reaches evaluation, where the point-count filters (`min_num_points`) subsume the old flag.
- Loader and datamodule tests updated to the new behavior.

## Related Issues

None.

## Checklist

- [x] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [x] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

## Additional Notes

Metric values on existing checkpoints will shift slightly: 0-point GT that the flag used to hide now reaches eval and is filtered there. This is a prerequisite for the occlusion recall split in the upcoming metrics PRs. Built on top of the current devel state, targets main following the PR queue.

## Additional Log and Media

`pytest autoware_ml/tests/transforms autoware_ml/tests/datamodule autoware_ml/tests/preprocessing autoware_ml/tests/configs autoware_ml/tests/metrics`: 273 passed at this branch head.

