### PR TITLE
feat(metrics): region, corridor and collision evaluation filters

### DIFF
--- a/autoware_ml/metrics/detection3d/geometry.py
+++ b/autoware_ml/metrics/detection3d/geometry.py
@@ -28,11 +28,31 @@ def wrap_angle(angle: float) -> float:
     return (float(angle) + pi) % (2.0 * pi) - pi
 
 
-def bev_corners(box: np.ndarray) -> np.ndarray:
-    """Return the four BEV corners of a box as a ``(4, 2)`` array.
+def bev_corners_batch(boxes: np.ndarray) -> np.ndarray:
+    """The four BEV corners of every box, as an ``(N, 4, 2)`` array.
 
-    Corners are ordered clockwise starting from the ``(+dx/2, +dy/2)`` corner
-    in the box frame, then rotated by ``yaw`` and shifted to the center.
+    Corners run clockwise from the ``(+dx/2, +dy/2)`` corner of the box frame,
+    rotated by ``yaw`` and shifted to the center.
+
+    Args:
+        boxes: Box rows ``(N, 7+)``.
+
+    Returns:
+        Corner coordinates ``(N, 4, 2)``.
+    """
+    boxes = np.asarray(boxes, dtype=np.float64)
+    half_dx, half_dy = boxes[:, 3] / 2.0, boxes[:, 4] / 2.0
+    local_x = np.stack([half_dx, half_dx, -half_dx, -half_dx], axis=1)
+    local_y = np.stack([half_dy, -half_dy, -half_dy, half_dy], axis=1)
+    cos_yaw = np.cos(boxes[:, 6])[:, None]
+    sin_yaw = np.sin(boxes[:, 6])[:, None]
+    corners_x = local_x * cos_yaw - local_y * sin_yaw + boxes[:, 0:1]
+    corners_y = local_x * sin_yaw + local_y * cos_yaw + boxes[:, 1:2]
+    return np.stack([corners_x, corners_y], axis=2)
+
+
+def bev_corners(box: np.ndarray) -> np.ndarray:
+    """:func:`bev_corners_batch` for a single box row, as a ``(4, 2)`` array.
 
     Args:
         box: Box row ``[cx, cy, cz, dx, dy, dz, yaw, ...]``.
@@ -40,21 +60,7 @@ def bev_corners(box: np.ndarray) -> np.ndarray:
     Returns:
         Corner coordinates ``(4, 2)``.
     """
-    center = box[:2].astype(np.float64)
-    half = box[3:5].astype(np.float64) / 2.0
-    yaw = float(box[6])
-    local = np.array(
-        [
-            [half[0], half[1]],
-            [half[0], -half[1]],
-            [-half[0], -half[1]],
-            [-half[0], half[1]],
-        ],
-        dtype=np.float64,
-    )
-    cos_yaw, sin_yaw = np.cos(yaw), np.sin(yaw)
-    rotation = np.array([[cos_yaw, -sin_yaw], [sin_yaw, cos_yaw]], dtype=np.float64)
-    return local @ rotation.T + center
+    return bev_corners_batch(np.asarray(box, dtype=np.float64)[None, :])[0]
 
 
 def corner_displacement(pred_box: np.ndarray, gt_box: np.ndarray) -> float:
@@ -124,27 +130,6 @@ def signed_nearest_surface_error(pred_box: np.ndarray, gt_box: np.ndarray) -> fl
         The signed error in meters.
     """
     return nearest_surface_distance(pred_box) - nearest_surface_distance(gt_box)
-
-
-def bev_corners_batch(boxes: np.ndarray) -> np.ndarray:
-    """:func:`bev_corners` for ``(N, 7+)`` boxes at once, as ``(N, 4, 2)``.
-
-    Args:
-        boxes: Box rows ``(N, 7+)``.
-
-    Returns:
-        Corner coordinates ``(N, 4, 2)``.
-    """
-    boxes = np.asarray(boxes, dtype=np.float64)
-    half_dx, half_dy = boxes[:, 3] / 2.0, boxes[:, 4] / 2.0
-    # Same counter-clockwise corner order as bev_corners.
-    local_x = np.stack([half_dx, half_dx, -half_dx, -half_dx], axis=1)
-    local_y = np.stack([half_dy, -half_dy, -half_dy, half_dy], axis=1)
-    cos_yaw = np.cos(boxes[:, 6])[:, None]
-    sin_yaw = np.sin(boxes[:, 6])[:, None]
-    corners_x = local_x * cos_yaw - local_y * sin_yaw + boxes[:, 0:1]
-    corners_y = local_x * sin_yaw + local_y * cos_yaw + boxes[:, 1:2]
-    return np.stack([corners_x, corners_y], axis=2)
 
 
 def corner_displacements(pred_boxes: np.ndarray, gt_boxes: np.ndarray) -> np.ndarray:

--- a/autoware_ml/metrics/filters.py
+++ b/autoware_ml/metrics/filters.py
@@ -1,0 +1,454 @@
+"""Concrete evaluation filters.
+
+The base :class:`~autoware_ml.metrics.base.MetricFilter` / ``IdentityFilter`` live
+in ``base.py`` (no heavy deps). Three filters live here. ``CorridorFilter`` keeps
+the elements inside a straight fixed strip ahead of ego and needs no map at all.
+``RegionFilter`` keeps the elements whose base_link position, transformed to the
+map frame by the per-frame ego pose, falls inside a chosen set of lanelet2
+regions, so any metric can be reported on the road or on the walkway.
+``CollisionFilter`` keeps the elements inside the ego collision area clipped to
+the road lanelets, the filter form of the collision model.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import lru_cache
+from math import atan2
+from typing import Any
+
+import numpy as np
+import shapely
+import torch
+
+from autoware_ml.metrics.base import MetricFilter, number_token
+from autoware_ml.metrics.detection3d.geometry import bev_corners_batch
+from autoware_ml.metrics.geometry.lanelet import (
+    KNOWN_REGION_TOKENS,
+    LaneletMap,
+    LaneletMapProvider,
+)
+from autoware_ml.metrics.geometry.reachability import (
+    Agent,
+    ReachabilityParams,
+    VehicleGeometry,
+    localized_surface,
+    wheeled_reachable_region,
+)
+
+
+# The lanelet2 regions a vehicle may drive on, shared by every consumer of the
+# collision model so the filter and the TTC provider cannot drift apart.
+DEFAULT_DRIVABLE_REGION: tuple[str, ...] = ("road", "road_shoulder", "crosswalk")
+
+
+def as_numpy(value: Any) -> np.ndarray:
+    """Frame metadata as a NumPy array, from any device.
+
+    Collation and Lightning's device transfer turn per-frame metadata (the ego
+    pose) into tensors that live on the evaluation device, and ``np.asarray``
+    alone cannot read a CUDA tensor.
+
+    Args:
+        value: Array-like or tensor, possibly on a CUDA device.
+
+    Returns:
+        A NumPy array on the CPU.
+    """
+    if isinstance(value, torch.Tensor):
+        return value.detach().cpu().numpy()
+    return np.asarray(value)
+
+
+def _to_map_xy(xyz: np.ndarray, ego2global: Any) -> np.ndarray:
+    """Transform base_link ``xyz`` (N, 3+) to map-frame xy via ``ego2global``."""
+    transform = as_numpy(ego2global).astype(np.float64)
+    homogeneous = np.concatenate([xyz[:, :3], np.ones((xyz.shape[0], 1))], axis=1)
+    return (homogeneous @ transform.T)[:, :2]
+
+
+def ego2global_pose(ego2global: Any) -> tuple[float, float, float]:
+    """Ego map-frame ``(x, y, heading)`` from a 4x4 ego-to-global transform.
+
+    Args:
+        ego2global: 4x4 ego-to-global transform.
+
+    Returns:
+        The map-frame ``(x, y, heading)`` triple.
+    """
+    matrix = as_numpy(ego2global).astype(np.float64)
+    return float(matrix[0, 3]), float(matrix[1, 3]), atan2(float(matrix[1, 0]), float(matrix[0, 0]))
+
+
+def box_footprints_map(boxes: np.ndarray, ego2global: Any) -> np.ndarray:
+    """Map-frame BEV footprint polygons for detection boxes.
+
+    ``boxes`` rows are ``[cx, cy, cz, dx, dy, dz, yaw, ...]`` in base_link. Each
+    footprint's four corners are transformed to the map frame so region
+    membership can be tested by overlap rather than by the box center alone.
+
+    Args:
+        boxes: Box rows ``(N, 7+)`` in base_link.
+        ego2global: 4x4 ego-to-global transform of the frame.
+
+    Returns:
+        One shapely footprint polygon per box, in the map frame.
+    """
+    corners = bev_corners_batch(boxes)  # (N, 4, 2) base_link
+    heights = np.repeat(boxes[:, 2], corners.shape[1])
+    corners3 = np.column_stack([corners.reshape(-1, 2), heights])
+    map_xy = _to_map_xy(corners3, ego2global).reshape(corners.shape)
+    return shapely.polygons(map_xy)
+
+
+def _is_boxes(elements: np.ndarray) -> bool:
+    """Elements are detection boxes ``[cx,cy,cz,dx,dy,dz,yaw,...]`` rather than bare points."""
+    return elements.ndim == 2 and elements.shape[1] >= 7
+
+
+def ego_collision_agent(
+    lanelet_map: LaneletMap,
+    x: float,
+    y: float,
+    heading: float,
+    max_speed_mps: float,
+    vehicle: VehicleGeometry,
+) -> Agent:
+    """Builds a wheeled agent representing the ego for use in collision
+    calculations.
+
+    The collision area trim (:class:`CollisionFilter`) and the collision TTC
+    provider build ego through this single function, so the two can never drift:
+    the speed is the lanelet speed limit at ego's position with ``max_speed_mps``
+    as the off-map fallback. Callers hold the ego pose in different forms, so
+    they read it out of their transform with :func:`ego2global_pose` first.
+
+    Args:
+        lanelet_map: The scene's parsed lanelet map.
+        x: Ego map-frame x in meters.
+        y: Ego map-frame y in meters.
+        heading: Ego map-frame heading in radians.
+        max_speed_mps: Off-map fallback speed in m/s.
+        vehicle: Ego body dimensions.
+
+    Returns:
+        Ego as a wheeled agent in the map frame.
+    """
+    return Agent.wheeled(
+        x,
+        y,
+        heading,
+        lanelet_map.speed_at(x, y, max_speed_mps),
+        front=vehicle.front,
+        rear=vehicle.rear,
+        width=vehicle.width,
+        min_turn_radius=vehicle.min_turn_radius,
+    )
+
+
+def signed_number_token(value: float) -> str:
+    """Key-safe token spelling the sign, e.g. ``plus0p2`` or ``minus0p2``.
+
+    Zero has no direction, so it carries no sign word.
+
+    Args:
+        value: Signed number to encode.
+
+    Returns:
+        The token, sign word first for a non-zero value.
+    """
+    if value == 0.0:
+        return number_token(0.0)
+    return ("minus" if value < 0.0 else "plus") + number_token(abs(value))
+
+
+def validated_region(region: list[str] | tuple[str, ...], owner: str) -> tuple[str, ...]:
+    """The region tokens as a tuple, rejecting anything lanelet2 does not name.
+
+    A typo would otherwise surface as a silently empty slice, so both map-backed
+    filters validate through here.
+
+    Args:
+        region: Literal lanelet2 tokens.
+        owner: Name of the calling filter, for the error message.
+
+    Returns:
+        The tokens as a tuple of strings.
+
+    Raises:
+        ValueError: If ``region`` is empty or names an unknown token.
+    """
+    if not region:
+        raise ValueError(f"{owner} needs at least one lanelet2 region token.")
+    tokens = tuple(str(token) for token in region)
+    unknown = sorted(set(tokens) - KNOWN_REGION_TOKENS)
+    if unknown:
+        raise ValueError(
+            f"Unknown lanelet2 region tokens {unknown}, known tokens: "
+            f"{sorted(KNOWN_REGION_TOKENS)}. (A known token absent from a "
+            "particular scene's map is fine, that slice is simply empty.)"
+        )
+    return tokens
+
+
+@dataclass(frozen=True)
+class RegionFilter(MetricFilter):
+    """Keep only elements inside a union of lanelet2 regions.
+
+    Points near the outer border of the whole mapped surface are naturally
+    noisy (high entropy, frequent misclassification), so the border can be
+    moved by a signed margin, negative eroding it and positive dilating it.
+
+    Attributes:
+        region: List of literal lanelet2 tokens (lanelet ``subtype`` or area
+            ``type``), e.g. ``[road, road_shoulder, crosswalk]`` for the
+            drivable region or ``[walkway]`` for the pedestrian-only region.
+        map_provider: Resolves a scene token to its :class:`LaneletMap`.
+        margin: Border shift in meters. Negative erodes, so outer-border points
+            stop counting while internal borders between adjacent regions stay
+            intact. Positive dilates, so the region additionally claims off-map
+            points within the margin, never points of another mapped region.
+        name: Display name prefixing the metric keys. Derived from the tokens
+            and margin when left empty.
+    """
+
+    region: tuple[str, ...]
+    map_provider: LaneletMapProvider
+    margin: float = 0.0
+    name: str = ""
+
+    required_eval_keys = ("ego2global", "scene_token")
+
+    def __post_init__(self) -> None:
+        """Validate the region tokens and derive the display name."""
+        object.__setattr__(self, "region", validated_region(self.region, "RegionFilter"))
+        object.__setattr__(self, "margin", float(self.margin))
+        if not self.name:
+            margin_token = f"_{signed_number_token(self.margin)}" if self.margin else ""
+            object.__setattr__(self, "name", "region_" + "_".join(self.region) + margin_token)
+
+    @property
+    def cache_key(self) -> str:
+        """Every parameter that shapes the mask, equal keys must mean equal masks.
+
+        The provider is part of that: a suite keeps one mask set per key, so two
+        filters that read different maps must not share it.
+        """
+        region = ",".join(sorted(self.region))
+        return f"region:{region}:{self.margin:g}:{self.map_provider.cache_key}"
+
+    def keep(self, xyz: np.ndarray, context: dict[str, Any]) -> np.ndarray:
+        """Mask of elements in the region.
+
+        Detection boxes (7 or more columns) belong to the region when their
+        footprint overlaps it (any part inside), so an object overhanging from
+        an off-region center still counts. Segmentation points (3 columns) use
+        point-in-polygon.
+
+        Args:
+            xyz: Points ``(N, 3)`` or box rows ``(N, 7+)`` in base_link.
+            context: Per-frame values with the ego pose and scene token.
+
+        Returns:
+            Boolean mask of elements in the region.
+        """
+        xyz = np.asarray(xyz, dtype=np.float64)
+        if xyz.shape[0] == 0:
+            return np.zeros((0,), dtype=bool)
+        lanelet_map = self.map_provider.get(context["scene_token"])
+        if _is_boxes(xyz):
+            footprints = box_footprints_map(xyz, context["ego2global"])
+            return lanelet_map.intersects(self.region, footprints, self.margin)
+        map_xy = _to_map_xy(xyz, context["ego2global"])
+        return lanelet_map.contains(self.region, map_xy, self.margin)
+
+    def available(self, context: dict[str, Any]) -> bool:
+        """False for scenes with no lanelet map, so the suite excludes them.
+
+        Args:
+            context: Per-frame values with the scene token.
+
+        Returns:
+            Whether the scene has a lanelet map.
+        """
+        return self.map_provider.available(context["scene_token"])
+
+
+@dataclass(frozen=True)
+class CorridorFilter(MetricFilter):
+    """Keep only elements inside a straight corridor ahead of ego.
+
+    The corridor is a forward strip in the ego frame: ``width_m`` across,
+    centered on the x axis, with no length bound of its own because distance
+    slicing is the range axis's job. It needs no map and no pose, so the slice
+    covers every scene. A detection box is kept when its footprint overlaps
+    the strip, a segmentation point when it lies inside it.
+
+    Attributes:
+        width_m: Full corridor width in meters, centered on the x axis.
+        name: Display name prefixing the metric keys.
+    """
+
+    width_m: float = 3.0
+    name: str = "corridor"
+
+    required_eval_keys = ()
+
+    def __post_init__(self) -> None:
+        """Validate the strip width."""
+        if self.width_m <= 0.0:
+            raise ValueError("width_m must be > 0.")
+        object.__setattr__(self, "width_m", float(self.width_m))
+
+    @property
+    def cache_key(self) -> str:
+        """Every parameter that shapes the mask, equal keys must mean equal masks."""
+        return f"corridor:w{self.width_m:g}"
+
+    def keep(self, xyz: np.ndarray, context: dict[str, Any]) -> np.ndarray:
+        """Mask of elements inside the strip (footprint overlap / point test).
+
+        Args:
+            xyz: Points ``(N, 3)`` or box rows ``(N, 7+)`` in base_link.
+            context: Unused, the strip lives in the ego frame.
+
+        Returns:
+            Boolean mask of elements inside the strip.
+        """
+        xyz = np.asarray(xyz, dtype=np.float64)
+        if xyz.shape[0] == 0:
+            return np.zeros((0,), dtype=bool)
+        half_width = self.width_m / 2.0
+        if _is_boxes(xyz):
+            corners = bev_corners_batch(xyz)
+            # The strip has no length bound, and no geometry library has an
+            # unbounded polygon: truncating it at the batch's own farthest corner
+            # is the same test for every box in the batch.
+            far = float(corners[:, :, 0].max())
+            if far <= 0.0:
+                return np.zeros(xyz.shape[0], dtype=bool)
+            strip = shapely.box(0.0, -half_width, far, half_width)
+            footprints = shapely.polygons(corners)
+            return np.asarray(shapely.intersects(strip, footprints), dtype=bool)
+        return (xyz[:, 0] >= 0.0) & (np.abs(xyz[:, 1]) <= half_width)
+
+
+@dataclass(frozen=True)
+class CollisionFilter(MetricFilter):
+    """Keep only elements in the ego's collision area, the filter form of the collision model.
+
+    The collision area is everything ego could collide with within the horizon
+    at the max map-legal speed under bounded steering, clipped to the road
+    lanelets so it follows the road on bends. A detection box is kept when its
+    footprint meets that region, a segmentation point when it lies inside it.
+    Planner-independent (never the driven path), and the same collision model
+    the criticality metrics use, so any other metric can be reported
+    in-path too.
+
+    The ego body has no default: it is a property of the platform, and a vehicle
+    silently evaluated with another vehicle's size gives a plausible looking
+    area that is simply wrong.
+
+    Attributes:
+        map_provider: Resolves a scene token to its :class:`LaneletMap`.
+        vehicle: Ego body dimensions, measured from the rear axle the pose refers to.
+        region: Road lanelet tokens the collision area is clipped to.
+        params: Ego propagation parameters.
+        max_speed_mps: Ego speed fallback where the map has no speed limit.
+        name: Display name prefixing the metric keys.
+    """
+
+    map_provider: LaneletMapProvider
+    vehicle: VehicleGeometry = field(kw_only=True)
+    region: tuple[str, ...] = field(default=DEFAULT_DRIVABLE_REGION, kw_only=True)
+    params: ReachabilityParams = field(default_factory=ReachabilityParams, kw_only=True)
+    max_speed_mps: float = field(default=16.7, kw_only=True)
+    name: str = field(default="collision", kw_only=True)
+
+    required_eval_keys = ("ego2global", "scene_token")
+
+    def __post_init__(self) -> None:
+        """Validate the road region tokens and the ego speed fallback."""
+        object.__setattr__(self, "region", validated_region(self.region, "CollisionFilter"))
+        if self.max_speed_mps <= 0.0:
+            raise ValueError("max_speed_mps must be > 0.")
+        object.__setattr__(self, "max_speed_mps", float(self.max_speed_mps))
+
+    @property
+    def cache_key(self) -> str:
+        """Every parameter that shapes the mask, equal keys must mean equal masks."""
+        region = ",".join(sorted(self.region))
+        params = self.params
+        return (
+            f"collision-area:v{self.max_speed_mps:g}"
+            f":b{self.vehicle.front:g}+{self.vehicle.rear:g}x{self.vehicle.width:g}"
+            f"r{self.vehicle.min_turn_radius:g}"
+            f":h{params.horizon_s:g},{params.dt_s:g},{params.max_lateral_accel_mps2:g}"
+            f",{params.min_radius_m:g},{params.arc_samples}:{region}"
+            f":{self.map_provider.cache_key}"
+        )
+
+    @lru_cache(maxsize=1)
+    def _region_for_pose(self, scene_token: str, x: float, y: float, heading: float):
+        """The ego collision area in the map frame for one ego pose.
+
+        The suite calls :meth:`keep` for the ground truth and the predictions of
+        the same frame in sequence and the area depends only on the pose, so one
+        cached entry serves both calls.
+        """
+        lanelet_map = self.map_provider.get(scene_token)
+        ego = ego_collision_agent(lanelet_map, x, y, heading, self.max_speed_mps, self.vehicle)
+        # The scene's whole drivable union is orders of magnitude larger than one
+        # ego pose can touch, and sealing it dominates the cost, so clip first.
+        drivable = localized_surface(ego, self.params, lanelet_map.region_union(self.region))
+        region = wheeled_reachable_region(ego, self.params, drivable)
+        if not region.is_empty:
+            shapely.prepare(region)
+        return region
+
+    def _ego_region(self, context: dict[str, Any]):
+        """The ego collision area in the map frame for this frame."""
+        return self._region_for_pose(
+            str(context["scene_token"]), *ego2global_pose(context["ego2global"])
+        )
+
+    def keep(self, xyz: np.ndarray, context: dict[str, Any]) -> np.ndarray:
+        """Mask of elements inside the ego collision area (footprint / point test).
+
+        Args:
+            xyz: Points ``(N, 3)`` or box rows ``(N, 7+)`` in base_link.
+            context: Per-frame values with the ego pose and scene token.
+
+        Returns:
+            Boolean mask of elements inside the collision area.
+        """
+        xyz = np.asarray(xyz, dtype=np.float64)
+        if xyz.shape[0] == 0:
+            return np.zeros((0,), dtype=bool)
+        region = self._ego_region(context)
+        if region.is_empty:
+            return np.zeros(xyz.shape[0], dtype=bool)
+        if _is_boxes(xyz):
+            footprints = box_footprints_map(xyz, context["ego2global"])
+            return np.asarray(shapely.intersects(region, footprints), dtype=bool)
+        map_xy = _to_map_xy(xyz, context["ego2global"])
+        points = shapely.points(map_xy[:, 0], map_xy[:, 1])
+        return np.asarray(shapely.contains(region, points), dtype=bool)
+
+    def available(self, context: dict[str, Any]) -> bool:
+        """False when the frame has no collision area, so the suite excludes it.
+
+        A scene without a lanelet map has none, and neither has a frame whose ego
+        pose sits off the drivable surface (an inaccurate map or localization).
+        Both would otherwise enter the slice with an empty in-path set, where a
+        missed object can never be counted because nothing is in path at all.
+
+        Args:
+            context: Per-frame values with the ego pose and scene token.
+
+        Returns:
+            Whether the frame has a collision area to evaluate against.
+        """
+        if not self.map_provider.available(context["scene_token"]):
+            return False
+        return not self._ego_region(context).is_empty

--- a/autoware_ml/metrics/geometry/lanelet.py
+++ b/autoware_ml/metrics/geometry/lanelet.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import logging
 import xml.etree.ElementTree as ET
 from collections import defaultdict
+from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import Protocol
@@ -490,16 +491,26 @@ class OsmPathResolver(Protocol):
 
     Two calls, because a scene may have no map at all: the provider asks for the
     path when it reads a map and asks :meth:`available` when a filter has to
-    decide whether the scene can take part in a map-based slice.
+    decide whether the scene can take part in a map-based slice. On top of that
+    it names the corpus it resolves against, so consumers can tell two providers
+    apart without reading a map.
     """
+
+    @property
+    def cache_key(self) -> str:
+        """The set of maps this resolver serves, e.g. the dataset root."""
+        ...
 
     def __call__(self, scene_token: object) -> str:
         """Path of the scene's ``lanelet2_map.osm``."""
+        ...
 
     def available(self, scene_token: object) -> bool:
         """Whether the scene has a map, decided without reading it."""
+        ...
 
 
+@dataclass(frozen=True)
 class LaneletMapProvider:
     """Resolves a scene token to its :class:`LaneletMap`.
 
@@ -508,16 +519,24 @@ class LaneletMapProvider:
     map is parsed once and reused, cached by path in :meth:`LaneletMap.from_osm`.
     A dataset adapter supplies the resolver (it knows the on-disk scene layout),
     tests inject a direct path.
+
+    Attributes:
+        resolve_osm: Resolver satisfying :class:`OsmPathResolver`, so it returns
+            a path when called and answers ``available``.
     """
 
-    def __init__(self, resolve_osm: OsmPathResolver) -> None:
-        """Store the scene-token to OSM-path resolver.
+    resolve_osm: OsmPathResolver
 
-        Args:
-            resolve_osm: Resolver satisfying :class:`OsmPathResolver`, so it
-                returns a path when called and answers ``available``.
+    @property
+    def cache_key(self) -> str:
+        """The set of maps this provider serves, taken from its resolver.
+
+        Consumers that group work by configuration, such as the evaluation
+        filters, have to tell two providers apart. The resolver knows which
+        corpus it points at, so the provider passes that through rather than
+        inventing an identity of its own.
         """
-        self._resolve_osm = resolve_osm
+        return self.resolve_osm.cache_key
 
     def get(self, scene_token: object) -> LaneletMap:
         """The scene's map, parsed on the first request and shared afterwards.
@@ -528,7 +547,7 @@ class LaneletMapProvider:
         Returns:
             The scene's parsed map.
         """
-        return LaneletMap.from_osm(self._resolve_osm(scene_token))
+        return LaneletMap.from_osm(self.resolve_osm(scene_token))
 
     def available(self, scene_token: object) -> bool:
         """Whether a lanelet map exists for the scene (no parse, no exception).
@@ -543,9 +562,10 @@ class LaneletMapProvider:
         Returns:
             Whether a map exists for the scene.
         """
-        return self._resolve_osm.available(scene_token)
+        return self.resolve_osm.available(scene_token)
 
 
+@dataclass(frozen=True)
 class T4LaneletMapResolver:
     """Resolves a T4 scene-directory token to its ``lanelet2_map.osm`` path.
 
@@ -555,15 +575,21 @@ class T4LaneletMapResolver:
     ``map/`` directory. :meth:`available` reports that up front so the region
     filters can exclude the scene, while :meth:`__call__` still raises if a map a
     caller expected to resolve is absent.
+
+    Attributes:
+        data_root: Dataset root the scene tokens are relative to.
     """
 
-    def __init__(self, data_root: str) -> None:
-        """Store the dataset root the scene tokens are relative to.
+    data_root: str
 
-        Args:
-            data_root: Dataset root directory.
-        """
-        self.data_root = str(data_root)
+    def __post_init__(self) -> None:
+        """Accept whatever the config layer hands over as the root path."""
+        object.__setattr__(self, "data_root", str(self.data_root))
+
+    @property
+    def cache_key(self) -> str:
+        """The dataset root, which is what decides the maps this resolver serves."""
+        return f"t4:{self.data_root}"
 
     def _osm_path(self, scene_token: object) -> Path:
         return Path(self.data_root) / str(scene_token) / "map" / "lanelet2_map.osm"

--- a/autoware_ml/metrics/geometry/reachability.py
+++ b/autoware_ml/metrics/geometry/reachability.py
@@ -495,6 +495,30 @@ def wheeled_reachable_set(
     return shapely.union_all(pieces)
 
 
+def localized_surface(
+    agent: Agent, params: ReachabilityParams, drivable: BaseGeometry
+) -> BaseGeometry:
+    """``drivable`` clipped to the square the agent can still touch by the horizon.
+
+    Sealing and sweeping cost grow with the surface's vertex count, and a whole
+    scene's drivable union is orders of magnitude larger than one agent's reach,
+    so every consumer clips it first. The clip cannot drop reachable area:
+    ``speed * horizon + body_reach`` is the reachable set's own radius.
+
+    Args:
+        agent: Agent the surface is localized around.
+        params: Shared reachability parameters.
+        drivable: Drivable surface in the map frame.
+
+    Returns:
+        The part of ``drivable`` within the agent's reach.
+    """
+    reach = agent.speed * params.horizon_s + agent.body_reach
+    return drivable.intersection(
+        box(agent.x - reach, agent.y - reach, agent.x + reach, agent.y + reach)
+    )
+
+
 def wheeled_reachable_region(
     agent: Agent, params: ReachabilityParams, drivable: BaseGeometry
 ) -> BaseGeometry:
@@ -605,10 +629,7 @@ class EgoReachability:
         # non-divisible horizon never gains a step beyond it.
         self.steps = int(params.horizon_s / params.dt_s + 1e-9)
         self._surface = drivable
-        reach = ego.speed * params.horizon_s + ego.body_reach
-        self._drivable = drivable.intersection(
-            box(ego.x - reach, ego.y - reach, ego.x + reach, ego.y + reach)
-        ).buffer(SURFACE_TOLERANCE_M)
+        self._drivable = localized_surface(ego, params, drivable).buffer(SURFACE_TOLERANCE_M)
         shapely.prepare(self._drivable)
         self._hat = wheeled_reachable_region(ego, params, self._drivable)
         shapely.prepare(self._hat)
@@ -683,10 +704,7 @@ class EgoReachability:
         # never against ego's clip (the approach can start outside it).
         surface = None
         if obj.kind == AgentKind.WHEELED:
-            reach = obj.speed * params.horizon_s + obj.body_reach
-            surface = self._surface.intersection(
-                box(obj.x - reach, obj.y - reach, obj.x + reach, obj.y + reach)
-            ).buffer(SURFACE_TOLERANCE_M)
+            surface = localized_surface(obj, params, self._surface).buffer(SURFACE_TOLERANCE_M)
             shapely.prepare(surface)
         for index in range(max(start_hat, start_gap), self.steps + 1):
             t = index * params.dt_s

--- a/autoware_ml/tests/metrics/test_region_filter.py
+++ b/autoware_ml/tests/metrics/test_region_filter.py
@@ -1,0 +1,454 @@
+"""Tests for the region-filter axis: lanelet parsing, membership, and suite use."""
+
+from __future__ import annotations
+
+
+import numpy as np
+import pytest
+import torch
+from shapely.geometry import Point, Polygon
+
+from autoware_ml.metrics.base import EvalStage
+from autoware_ml.metrics.detection3d.mean_ap import MeanAP
+from autoware_ml.metrics.detection3d.suite import Detection3DMetricSuite
+from autoware_ml.metrics.filters import CollisionFilter, CorridorFilter, RegionFilter
+from autoware_ml.metrics.geometry.lanelet import (
+    LaneletMap,
+    LaneletMapProvider,
+    T4LaneletMapResolver,
+    load_lanelet_speeds,
+    load_region_polygons,
+)
+from autoware_ml.metrics.geometry.reachability import ReachabilityParams, VehicleGeometry
+
+# Ego body in vehicle description terms, measured from the rear axle: 2.0 m wide,
+# 3.79 m ahead of the reference point and 1.1 m behind it.
+EGO = VehicleGeometry(
+    wheel_base=2.79,
+    front_overhang=1.0,
+    rear_overhang=1.1,
+    wheel_tread=1.64,
+    left_overhang=0.18,
+    right_overhang=0.18,
+    max_steer_angle=0.64,
+)
+
+_MINI_OSM = """<?xml version='1.0'?>
+<osm>
+  <node id='1'><tag k='local_x' v='0'/><tag k='local_y' v='0'/></node>
+  <node id='2'><tag k='local_x' v='10'/><tag k='local_y' v='0'/></node>
+  <node id='3'><tag k='local_x' v='0'/><tag k='local_y' v='4'/></node>
+  <node id='4'><tag k='local_x' v='10'/><tag k='local_y' v='4'/></node>
+  <node id='5'><tag k='local_x' v='0'/><tag k='local_y' v='5'/></node>
+  <node id='6'><tag k='local_x' v='10'/><tag k='local_y' v='5'/></node>
+  <node id='7'><tag k='local_x' v='0'/><tag k='local_y' v='7'/></node>
+  <node id='8'><tag k='local_x' v='10'/><tag k='local_y' v='7'/></node>
+  <way id='100'><nd ref='1'/><nd ref='2'/></way>
+  <way id='101'><nd ref='3'/><nd ref='4'/></way>
+  <way id='102'><nd ref='5'/><nd ref='6'/></way>
+  <way id='103'><nd ref='7'/><nd ref='8'/></way>
+  <relation id='200'>
+    <member type='way' ref='101' role='left'/>
+    <member type='way' ref='100' role='right'/>
+    <tag k='type' v='lanelet'/><tag k='subtype' v='road'/><tag k='speed_limit' v='36'/>
+  </relation>
+  <relation id='201'>
+    <member type='way' ref='103' role='left'/>
+    <member type='way' ref='102' role='right'/>
+    <tag k='type' v='lanelet'/><tag k='subtype' v='walkway'/>
+  </relation>
+</osm>
+"""
+
+
+class _StubProvider:
+    """Returns one fixed LaneletMap for every scene token.
+
+    ``no_map`` names scene tokens that have no lanelet map: ``available`` reports
+    them False (so the suite excludes them) and ``get`` raises if one is ever
+    loaded anyway, guarding that the suite never touches a map-less scene's map.
+    """
+
+    def __init__(
+        self, lanelet_map: LaneletMap, no_map: tuple[object, ...] = (), corpus: str = "stub"
+    ) -> None:
+        self._map = lanelet_map
+        self._no_map = set(no_map)
+        self._corpus = corpus
+
+    @property
+    def cache_key(self) -> str:
+        return self._corpus
+
+    def get(self, scene_token: object) -> LaneletMap:
+        if scene_token in self._no_map:
+            raise FileNotFoundError(f"map loaded for a scene declared map-less: {scene_token!r}")
+        return self._map
+
+    def available(self, scene_token: object) -> bool:
+        return scene_token not in self._no_map
+
+
+def _road_map() -> LaneletMap:
+    # A rectangular road region covering x in [0, 50], y in [-10, 10] (map frame).
+    return LaneletMap({"road": [Polygon([(0, -10), (50, -10), (50, 10), (0, 10)])]})
+
+
+def test_load_region_polygons_keys_lanelets_by_subtype(tmp_path) -> None:
+    path = tmp_path / "map.osm"
+    path.write_text(_MINI_OSM)
+
+    regions = load_region_polygons(str(path))
+
+    assert regions["road"], "expected road lanelet polygons"
+    assert regions["walkway"], "expected walkway lanelet polygons"
+    assert all(polygon.is_valid for polygon in regions["road"] + regions["walkway"])
+
+
+def test_region_filter_membership() -> None:
+    region_filter = RegionFilter(["road"], _StubProvider(_road_map()))
+    xyz = np.array([[10.0, 0.0, 0.0], [100.0, 0.0, 0.0]])  # inside road, off-road
+    keep = region_filter.keep(xyz, {"ego2global": np.eye(4), "scene_token": "scene"})
+    assert keep.tolist() == [True, False]
+
+
+def test_region_filter_box_footprint_any_overlap() -> None:
+    # Road strip y in [-3, 3]. A box centered at y=4 (off road) but 4 m wide
+    # overhangs onto the road: center-in-region drops it, footprint any-overlap
+    # keeps it. A box at y=8 is fully off the road and dropped.
+    region_filter = RegionFilter(["road"], _StubProvider(_narrow_road_map()))
+    context = {"ego2global": np.eye(4), "scene_token": "scene"}
+    boxes = np.array(
+        [
+            [10.0, 4.0, 0.0, 4.0, 4.0, 1.5, 0.0, 0.0, 0.0],  # y in [2, 6], overlaps road
+            [10.0, 8.0, 0.0, 4.0, 4.0, 1.5, 0.0, 0.0, 0.0],  # footprint y in [6, 10] -> off road
+        ]
+    )
+    assert region_filter.keep(boxes, context).tolist() == [True, False]
+
+
+def _narrow_road_map() -> LaneletMap:
+    # A road strip x in [0, 50], y in [-3, 3] (map frame) to exercise the road overlap.
+    return LaneletMap({"road": [Polygon([(0, -3), (50, -3), (50, 3), (0, 3)])]})
+
+
+def test_collision_filter_keeps_forward_reachable_on_road() -> None:
+    # The collision area is the ego reachable region (curvature-bounded, clipped
+    # to the road): a point ahead on the centerline is kept, one on the road but
+    # past the horizon, or off the road altogether, is dropped.
+    collision_filter = CollisionFilter(
+        _StubProvider(_road_map()),
+        vehicle=EGO,
+        region=["road"],
+        max_speed_mps=10.0,
+        params=ReachabilityParams(horizon_s=4.0, dt_s=0.1),
+    )
+    context = {"ego2global": np.eye(4), "scene_token": "scene"}
+    xyz = np.array(
+        [
+            [10.0, 0.0, 0.0],  # ahead on the centerline, reachable -> keep
+            [48.0, 0.0, 0.0],  # on the road but past 10 m/s * 4 s of reach -> drop
+            [-10.0, 0.0, 0.0],  # the road starts at x = 0, so this is off it -> drop
+            [100.0, 0.0, 0.0],  # off the road (x > 50) -> drop
+        ]
+    )
+    assert collision_filter.keep(xyz, context).tolist() == [True, False, False, False]
+
+
+def test_collision_filter_curvature_bound_excludes_close_lateral() -> None:
+    # At speed the ego cannot swerve far sideways over a short distance, so a point
+    # 8 m to the side only 5 m ahead is not reachable within the horizon.
+    collision_filter = CollisionFilter(
+        _StubProvider(_road_map()),
+        vehicle=EGO,
+        region=["road"],
+        max_speed_mps=10.0,
+        params=ReachabilityParams(horizon_s=4.0, dt_s=0.1),
+    )
+    context = {"ego2global": np.eye(4), "scene_token": "scene"}
+    assert collision_filter.keep(np.array([[5.0, 8.0, 0.0]]), context).tolist() == [False]
+
+
+def test_collision_filter_required_keys() -> None:
+    collision_filter = CollisionFilter(_StubProvider(_road_map()), vehicle=EGO)
+    assert collision_filter.required_eval_keys == (
+        "ego2global",
+        "scene_token",
+    )
+
+
+def test_corridor_filter_is_a_forward_strip_without_a_map() -> None:
+    # The corridor is a fixed-width forward strip in the ego frame with no
+    # length bound (distance slicing is the range axis's job). No map, no
+    # pose, no context keys.
+    corridor_filter = CorridorFilter(width_m=3.0)
+    assert corridor_filter.required_eval_keys == ()
+    xyz = np.array(
+        [
+            [10.0, 0.0, 0.0],  # ahead on the centerline -> keep
+            [200.0, 1.4, 0.0],  # far ahead, inside the half width -> keep
+            [10.0, 2.0, 0.0],  # beyond the half width -> drop
+            [-1.0, 0.0, 0.0],  # behind ego -> drop
+        ]
+    )
+    assert corridor_filter.keep(xyz, {}).tolist() == [True, True, False, False]
+
+
+def test_corridor_filter_keeps_overlapping_box_footprints() -> None:
+    # A box counts when the forward part of its footprint overlaps the strip,
+    # so a box overhanging the strip edge or straddling the ego x axis is kept.
+    corridor_filter = CorridorFilter(width_m=3.0)
+    boxes = np.array(
+        [
+            # [cx, cy, cz, dx, dy, dz, yaw]
+            [10.0, 0.0, 0.0, 4.0, 2.0, 1.5, 0.0],  # centered inside -> keep
+            [10.0, 2.2, 0.0, 4.0, 2.0, 1.5, 0.0],  # overhangs the edge -> keep
+            [10.0, 4.0, 0.0, 4.0, 2.0, 1.5, 0.0],  # fully beside -> drop
+            [-5.0, 0.0, 0.0, 4.0, 2.0, 1.5, 0.0],  # fully behind -> drop
+            [-1.0, 0.0, 0.0, 4.0, 2.0, 1.5, 0.7853981],  # nose crosses x=0 -> keep
+        ]
+    )
+    assert corridor_filter.keep(boxes, {}).tolist() == [True, True, False, False, True]
+
+
+def test_filters_accept_tensor_metadata() -> None:
+    # Collation + Lightning device transfer deliver the frame metadata as
+    # tensors, not numpy arrays, filters must convert (cuda included).
+    region_filter = RegionFilter(["road"], _StubProvider(_road_map()))
+    keep = region_filter.keep(
+        np.array([[10.0, 0.0, 0.0]]),
+        {"ego2global": torch.eye(4), "scene_token": "scene"},
+    )
+    assert keep.tolist() == [True]
+
+    collision_filter = CollisionFilter(_StubProvider(_road_map()), vehicle=EGO, region=["road"])
+    keep = collision_filter.keep(
+        np.array([[10.0, 0.0, 0.0]]),
+        {"ego2global": torch.eye(4), "scene_token": "scene"},
+    )
+    assert keep.tolist() == [True]
+
+
+def test_region_filter_margin_erodes_outer_border_only() -> None:
+    # Road spans y in [-10, 0], walkway y in [0, 3], adjacent regions. The margin
+    # erodes only the OUTER border of their union: a road point near the shared
+    # road-walkway border survives, one near the true outer border is dropped.
+    road = Polygon([(0, -10), (50, -10), (50, 0), (0, 0)])
+    walkway = Polygon([(0, 0), (50, 0), (50, 3), (0, 3)])
+    lanelet_map = LaneletMap({"road": [road], "walkway": [walkway]})
+    context = {"ego2global": np.eye(4), "scene_token": "scene"}
+
+    eroded = RegionFilter(["road"], _StubProvider(lanelet_map), margin=-0.5)
+    near_internal = np.array([[10.0, -0.1, 0.0]])  # 0.1 m from the road-walkway border
+    near_outer = np.array([[10.0, -9.8, 0.0]])  # 0.2 m from the outer border
+    assert eroded.keep(near_internal, context).tolist() == [True]
+    assert eroded.keep(near_outer, context).tolist() == [False]
+    assert eroded.name == "region_road_minus0p5"
+
+
+def test_region_filter_positive_margin_grows_into_off_map_space_only() -> None:
+    # Same adjacent road+walkway map. Expanding the road outward claims off-map
+    # points within the margin of the road, but never points that belong to
+    # another mapped region (the walkway strip stays the walkway's).
+    road = Polygon([(0, -10), (50, -10), (50, 0), (0, 0)])
+    walkway = Polygon([(0, 0), (50, 0), (50, 3), (0, 3)])
+    lanelet_map = LaneletMap({"road": [road], "walkway": [walkway]})
+    context = {"ego2global": np.eye(4), "scene_token": "scene"}
+
+    expanded = RegionFilter(["road"], _StubProvider(lanelet_map), margin=0.5)
+    off_map_near_road = np.array([[10.0, -10.3, 0.0]])  # 0.3 m below the road's outer border
+    on_walkway = np.array([[10.0, 0.2, 0.0]])  # inside the adjacent walkway
+    far_off_map = np.array([[10.0, -11.0, 0.0]])  # 1.0 m below, beyond the margin
+    assert expanded.keep(off_map_near_road, context).tolist() == [True]
+    assert expanded.keep(on_walkway, context).tolist() == [False]
+    assert expanded.keep(far_off_map, context).tolist() == [False]
+    assert expanded.name == "region_road_plus0p5"
+
+
+def test_region_filter_name_and_cache_key() -> None:
+    region_filter = RegionFilter(["road", "crosswalk"], _StubProvider(_road_map()))
+    assert region_filter.name == "region_road_crosswalk"
+    assert region_filter.required_eval_keys == ("ego2global", "scene_token")
+
+
+def test_filter_cache_keys_separate_two_corpora() -> None:
+    # A suite keeps one mask set per cache key, so filters that read different
+    # maps must not collide, while equal configurations still share the work.
+    road = _road_map()
+    first = RegionFilter(["road"], _StubProvider(road, corpus="t4:/data/a"))
+    second = RegionFilter(["road"], _StubProvider(road, corpus="t4:/data/b"))
+    same = RegionFilter(["road"], _StubProvider(road, corpus="t4:/data/a"))
+
+    assert first.cache_key != second.cache_key
+    assert first.cache_key == same.cache_key
+    assert first.name == second.name  # the reported slice is still the same one
+
+
+def test_region_filter_rejects_unknown_tokens() -> None:
+    # A typo (e.g. 'sidewalk', the lanelet2 name is 'walkway') fails loud at
+    # construction, not silently as an empty slice.
+    with pytest.raises(ValueError, match="Unknown lanelet2 region tokens"):
+        RegionFilter(["sidewalk"], _StubProvider(_road_map()))
+
+
+def test_region_absent_from_scene_is_empty_not_an_error() -> None:
+    # 'walkway' is a valid token but this scene's map has none: the slice is
+    # legitimately empty (membership false everywhere), the eval keeps running.
+    walkway_filter = RegionFilter(["walkway"], _StubProvider(_road_map()), margin=0.2)
+    keep = walkway_filter.keep(
+        np.array([[10.0, 0.0, 0.0]]), {"ego2global": np.eye(4), "scene_token": "scene"}
+    )
+    assert keep.tolist() == [False]
+
+
+def _box(x: float) -> list[float]:
+    return [x, 0.0, 0.0, 4.0, 2.0, 1.5, 0.0, 0.0, 0.0]
+
+
+def test_detection_suite_region_filter_restricts_gt() -> None:
+    # Two GT cars, one on the road (x=10), one off-road (x=100). One prediction
+    # matches the road car. The whole-scene metric sees 2 GT, the road slice 1.
+    region = RegionFilter(["road"], _StubProvider(_road_map()))
+    suite = Detection3DMetricSuite(
+        components=[
+            MeanAP(stages=["test"]),
+            MeanAP(stages=["test"], filter=region),
+        ],
+        class_names=("car",),
+        ranges=(),
+    )
+    gt = torch.tensor([_box(10.0), _box(100.0)])
+    suite.update(
+        {
+            "predictions": [
+                {
+                    "bboxes_3d": torch.tensor([_box(10.0)]),
+                    "scores_3d": torch.tensor([0.9]),
+                    "labels_3d": torch.tensor([0]),
+                }
+            ],
+            "gt_boxes": [gt],
+            "gt_labels": [torch.tensor([0, 0])],
+            "ego2global": [np.eye(4)],
+            "scene_token": ["scene"],
+        }
+    )
+    report = suite.result(EvalStage.TEST)
+    assert report["gt_count_car"] == pytest.approx(2.0)
+    assert report["region_road/gt_count_car"] == pytest.approx(1.0)
+
+
+# --------------------------------------------------------------------------- #
+# Scenes without a lanelet map: excluded from filtered slices, kept whole-scene
+# --------------------------------------------------------------------------- #
+
+
+def test_region_filter_available_delegates_to_provider() -> None:
+    provider = _StubProvider(_road_map(), no_map=("s_nomap",))
+    region_filter = RegionFilter(["road"], provider)
+    assert region_filter.available({"scene_token": "s_map"}) is True
+    assert region_filter.available({"scene_token": "s_nomap"}) is False
+
+
+def test_lanelet_resolver_available_and_call_are_distinct(tmp_path) -> None:
+    # available() is a pure existence check, __call__ still fails loud when absent.
+    resolver = T4LaneletMapResolver(str(tmp_path))
+    scene = "db/uuid/0"
+    assert resolver.available(scene) is False
+    with pytest.raises(FileNotFoundError):
+        resolver(scene)
+    map_path = tmp_path / scene / "map" / "lanelet2_map.osm"
+    map_path.parent.mkdir(parents=True)
+    map_path.write_text("<osm></osm>")
+    assert resolver.available(scene) is True
+    assert resolver(scene) == str(map_path)
+
+
+def test_map_provider_available_delegates_to_resolver() -> None:
+    class _Resolver:
+        def available(self, scene_token: object) -> bool:
+            return scene_token == "yes"
+
+    provider = LaneletMapProvider(_Resolver())
+    assert provider.available("yes") is True
+    assert provider.available("no") is False
+
+
+def test_detection_suite_excludes_scene_without_lanelet_map() -> None:
+    # Two frames, one GT car on the road each, 's_nomap' has no map. Whole-scene
+    # sees both GT, the road slice keeps only the mapped scene's, and coverage
+    # records 2 seen / 1 covered.
+    region = RegionFilter(["road"], _StubProvider(_road_map(), no_map=("s_nomap",)))
+    suite = Detection3DMetricSuite(
+        components=[MeanAP(stages=["test"]), MeanAP(stages=["test"], filter=region)],
+        class_names=("car",),
+        ranges=(),
+    )
+    suite.update(
+        {
+            "predictions": [
+                {
+                    "bboxes_3d": torch.tensor([_box(10.0)]),
+                    "scores_3d": torch.tensor([0.9]),
+                    "labels_3d": torch.tensor([0]),
+                },
+                {
+                    "bboxes_3d": torch.zeros((0, 9)),
+                    "scores_3d": torch.zeros((0,)),
+                    "labels_3d": torch.zeros((0,), dtype=torch.long),
+                },
+            ],
+            "gt_boxes": [torch.tensor([_box(10.0)]), torch.tensor([_box(10.0)])],
+            "gt_labels": [torch.tensor([0]), torch.tensor([0])],
+            "ego2global": [np.eye(4), np.eye(4)],
+            "scene_token": ["s_map", "s_nomap"],
+        }
+    )
+    report = suite.result(EvalStage.TEST)
+    assert report["gt_count_car"] == pytest.approx(2.0)
+    assert report["region_road/gt_count_car"] == pytest.approx(1.0)
+    assert suite.region_frames_seen.tolist() == [2]
+    assert suite.region_frames_covered.tolist() == [1]
+    # The uncovered frame is omitted from the filtered state entirely, so
+    # per-frame denominators only count covered frames.
+    assert len(suite.state_for(None, region).samples) == 1
+    assert len(suite.state_for(None).samples) == 2
+
+
+def test_load_lanelet_speeds_parses_km_h_to_mps(tmp_path) -> None:
+    path = tmp_path / "map.osm"
+    path.write_text(_MINI_OSM)
+    speeds = load_lanelet_speeds(str(path))
+    assert len(speeds) == 1
+    polygon, speed = speeds[0]
+    assert speed == pytest.approx(10.0)  # 36 km/h -> 10 m/s
+    assert polygon.contains(Point(5.0, 2.0))
+
+
+def test_lanelet_map_speed_at_lookup(tmp_path) -> None:
+    path = tmp_path / "map.osm"
+    path.write_text(_MINI_OSM)
+    lanelet_map = LaneletMap(load_region_polygons(str(path)), load_lanelet_speeds(str(path)))
+    assert lanelet_map.speed_at(5.0, 2.0, default=99.0) == pytest.approx(10.0)  # inside the lane
+    assert lanelet_map.speed_at(50.0, 50.0, default=99.0) == pytest.approx(99.0)  # off-lane
+
+
+def test_region_filter_eroded_margin_tests_the_surviving_region_part() -> None:
+    # Road x in [0, 10] and walkway x in [10, 20] share the internal border x=10;
+    # the union spans y in [0, 10] over the road and y in [-5, 10] over the walkway.
+    lanelet_map = LaneletMap(
+        {
+            "road": [Polygon([(0, 0), (10, 0), (10, 10), (0, 10)])],
+            "walkway": [Polygon([(10, -5), (20, -5), (20, 10), (10, 10)])],
+        }
+    )
+    # Overlaps the road only inside the 2 m outer band (y < 2 there) while also
+    # reaching the walkway's eroded interior, so testing the region and the eroded
+    # surface separately would wrongly keep it in the road slice.
+    band_straddler = Polygon([(8, 0.5), (13, 0.5), (13, 1.5), (8, 1.5)])
+    # Control: genuinely overlaps the road's surviving part.
+    inside = Polygon([(4, 4), (6, 4), (6, 6), (4, 6)])
+
+    mask = lanelet_map.intersects(("road",), [band_straddler, inside], margin=-2.0)
+
+    assert mask.tolist() == [False, True]


### PR DESCRIPTION
## Summary

Selection filters implementing the region, corridor and collision evaluation slices.

- `RegionFilter` keeps elements inside a union of lanelet2 regions, box footprints by overlap and points by membership, with an explicit `available()` check so map-less scenes are excluded from filtered slices instead of failing.
- `CorridorFilter` keeps a straight forward strip in the ego frame, map-free so the slice covers every scene, with distance left to the range axis.
- `CollisionFilter` is the filter form of the collision model (#100): it keeps whatever meets the area ego can reach within the horizon at max map-legal speed under bounded steering, clipped to the road lanelets.
- Filters declare the frame metadata they require and carry a stable name and cache key for suite slicing.

## Related Issues

Stacked on #100.

## Checklist

- [x] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [x] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

## Additional Notes

The detection suite consumes these through the filter axis added in #98. Segmentation suites follow later in the stack.

## Additional Log and Media

`pytest autoware_ml/tests/{metrics,configs,datamodule}`: 159 passed, 1 skipped at this branch head.



