### PR TITLE
feat(datamodule): add image schema

### DIFF
--- a/autoware_ml/databases/schemas/dataset_schemas.py
+++ b/autoware_ml/databases/schemas/dataset_schemas.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, ConfigDict
 from autoware_ml.databases.schemas.base_schemas import DatasetTableColumn, DataModelInterface
 from autoware_ml.databases.schemas.box3d_schemas import Box3DDataModel, Box3DDatasetSchema
 from autoware_ml.databases.schemas.lidar_frames import LidarFrameDatasetSchema, LidarFrameDataModel
+from autoware_ml.databases.schemas.image_frames import ImageFrameDatasetSchema, ImageFrameDataModel
 from autoware_ml.databases.schemas.category_mapping import (
     CategoryMappingDataModel,
     CategoryMappingDatasetSchema,
@@ -76,6 +77,11 @@ class DatasetTableSchema:
     # LiDAR Sources Schema
     LIDAR_SOURCES = DatasetTableColumn(
         "lidar_sources", pl.List(pl.Struct(LidarSourceDatasetSchema.to_polars_field_schema()))
+    )
+
+    # Image Frames Schema
+    IMAGE_FRAMES = DatasetTableColumn(
+        "image_frames", pl.List(pl.Struct(ImageFrameDatasetSchema.to_polars_field_schema()))
     )
 
     # Category Schema
@@ -143,6 +149,7 @@ class DatasetRecord(BaseModel, DataModelInterface):
 
     lidar_frames: Sequence[LidarFrameDataModel]
     lidar_sources: Sequence[LidarSourceDataModel] | None
+    image_frames: Sequence[ImageFrameDataModel] | None
     category_mapping: CategoryMappingDataModel | None
     boxes_3d: Sequence[Box3DDataModel] | None
 
@@ -172,6 +179,13 @@ class DatasetRecord(BaseModel, DataModelInterface):
             ]
         else:
             data_model[DatasetTableSchema.LIDAR_SOURCES.name] = []
+
+        if self.image_frames:
+            data_model[DatasetTableSchema.IMAGE_FRAMES.name] = [
+                image_frame.to_dictionary() for image_frame in self.image_frames
+            ]
+        else:
+            data_model[DatasetTableSchema.IMAGE_FRAMES.name] = []
 
         if self.category_mapping:
             data_model[DatasetTableSchema.CATEGORY_MAPPING.name] = (
@@ -215,6 +229,15 @@ class DatasetRecord(BaseModel, DataModelInterface):
         else:
             lidar_sources = None
 
+        image_frames = data_model[DatasetTableSchema.IMAGE_FRAMES.name]
+        if image_frames is not None:
+            image_frames = [
+                ImageFrameDataModel.load_from_dictionary(image_frame)
+                for image_frame in image_frames
+            ]
+        else:
+            image_frames = None
+
         category_mapping = data_model[DatasetTableSchema.CATEGORY_MAPPING.name]
         if category_mapping is not None:
             category_mapping = CategoryMappingDataModel.load_from_dictionary(category_mapping)
@@ -237,6 +260,7 @@ class DatasetRecord(BaseModel, DataModelInterface):
             scenario_name=data_model[DatasetTableSchema.SCENARIO_NAME.name],
             lidar_frames=lidar_frames,
             lidar_sources=lidar_sources,
+            image_frames=image_frames,
             category_mapping=category_mapping,
             boxes_3d=boxes_3d,
         )

--- a/autoware_ml/databases/schemas/dataset_schemas.py
+++ b/autoware_ml/databases/schemas/dataset_schemas.py
@@ -81,7 +81,8 @@ class DatasetTableSchema:
 
     # Image Frames Schema
     IMAGE_FRAMES = DatasetTableColumn(
-        "image_frames", pl.List(pl.Struct(ImageFrameDatasetSchema.to_polars_field_schema()))
+        "image_frames",
+        pl.List(pl.List(pl.Struct(ImageFrameDatasetSchema.to_polars_field_schema()))),
     )
 
     # Category Schema
@@ -149,7 +150,7 @@ class DatasetRecord(BaseModel, DataModelInterface):
 
     lidar_frames: Sequence[LidarFrameDataModel]
     lidar_sources: Sequence[LidarSourceDataModel] | None
-    image_frames: Sequence[ImageFrameDataModel] | None
+    image_frames: Sequence[Sequence[ImageFrameDataModel]] | None
     category_mapping: CategoryMappingDataModel | None
     boxes_3d: Sequence[Box3DDataModel] | None
 
@@ -182,7 +183,8 @@ class DatasetRecord(BaseModel, DataModelInterface):
 
         if self.image_frames:
             data_model[DatasetTableSchema.IMAGE_FRAMES.name] = [
-                image_frame.to_dictionary() for image_frame in self.image_frames
+                [image_frame.to_dictionary() for image_frame in image_channel_frames]
+                for image_channel_frames in self.image_frames
             ]
         else:
             data_model[DatasetTableSchema.IMAGE_FRAMES.name] = []
@@ -232,8 +234,11 @@ class DatasetRecord(BaseModel, DataModelInterface):
         image_frames = data_model[DatasetTableSchema.IMAGE_FRAMES.name]
         if image_frames is not None:
             image_frames = [
-                ImageFrameDataModel.load_from_dictionary(image_frame)
-                for image_frame in image_frames
+                [
+                    ImageFrameDataModel.load_from_dictionary(image_frame)
+                    for image_frame in image_channel_frames
+                ]
+                for image_channel_frames in image_frames
             ]
         else:
             image_frames = None

--- a/autoware_ml/databases/schemas/image_frames.py
+++ b/autoware_ml/databases/schemas/image_frames.py
@@ -1,0 +1,221 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Any
+
+import numpy as np
+import numpy.typing as npt
+import polars as pl
+from pydantic import BaseModel, ConfigDict
+
+from autoware_ml.databases.schemas.base_schemas import (
+    BaseFieldSchema,
+    DatasetTableColumn,
+    DataModelInterface,
+)
+
+
+@dataclass(frozen=True)
+class ImageFrameDatasetSchema(BaseFieldSchema):
+    """
+    Dataclass to define polars schema for columns related to image frames.
+    """
+
+    image_frame_id = DatasetTableColumn("image_frame_id", pl.String)
+    image_sensor_id = DatasetTableColumn("image_sensor_id", pl.String)
+    image_sensor_channel_name = DatasetTableColumn("image_sensor_channel_name", pl.String)
+    image_timestamp_seconds = DatasetTableColumn("image_timestamp_seconds", pl.Float64)
+    image_path = DatasetTableColumn("image_path", pl.String)
+    image_height = DatasetTableColumn("image_height", pl.Int32)
+    image_width = DatasetTableColumn("image_width", pl.Int32)
+    cam2img = DatasetTableColumn("cam2img", pl.Array(pl.Float32, shape=(3, 3)))
+    image_sensor_to_ego_pose_matrix = DatasetTableColumn(
+        "image_sensor_to_ego_pose_matrix", pl.Array(pl.Float32, shape=(4, 4))
+    )
+    image_frame_ego_pose_to_global_matrix = DatasetTableColumn(
+        "image_frame_ego_pose_to_global_matrix", pl.Array(pl.Float32, shape=(4, 4))
+    )
+    lidar2cam = DatasetTableColumn("lidar2cam", pl.Array(pl.Float32, shape=(4, 4)))
+    lidar2img = DatasetTableColumn("lidar2img", pl.Array(pl.Float32, shape=(4, 4)))
+
+
+class ImageFrameDataModel(BaseModel, DataModelInterface):
+    """
+    Image frame data model that can be shared by multiple datasets. It saves the metadata of a
+    single camera keyframe.
+
+    Attributes:
+      image_frame_id: Image frame ID (sample data token).
+      image_sensor_id: Image sensor ID (calibrated sensor token).
+      image_sensor_channel_name: Image sensor channel name, e.g. CAM_FRONT.
+      image_timestamp_seconds: Image timestamp in seconds.
+      image_path: Image path.
+      image_height: Image height in pixels. Set to None if it's not available.
+      image_width: Image width in pixels. Set to None if it's not available.
+      cam2img: Camera intrinsic matrix (3, 3).
+      image_sensor_to_ego_pose_matrix: Transformation matrix from the image sensor of this frame
+        to the ego pose of this image frame.
+      image_frame_ego_pose_to_global_matrix: Transformation matrix from the ego pose of this
+        image frame to the global frame.
+      lidar2cam: Transformation matrix from LiDAR frame to camera frame (4, 4).
+      lidar2img: Projection matrix from LiDAR frame to image plane (4, 4). Set to None if unavailable.
+    """
+
+    model_config = ConfigDict(frozen=True, strict=True, arbitrary_types_allowed=True)
+
+    image_frame_id: str
+    image_sensor_id: str
+    image_sensor_channel_name: str
+    image_timestamp_seconds: float
+    image_path: str
+    image_height: int | None
+    image_width: int | None
+    cam2img: npt.NDArray[np.float64]  # (3, 3)
+    image_sensor_to_ego_pose_matrix: npt.NDArray[np.float64]  # (4, 4)
+    image_frame_ego_pose_to_global_matrix: npt.NDArray[np.float64]  # (4, 4)
+    lidar2cam: npt.NDArray[np.float64]  # (4, 4)
+    lidar2img: npt.NDArray[np.float64] | None  # (4, 4) or None
+
+    @property
+    def cam2img_fp32(self) -> npt.NDArray[np.float32]:
+        """
+        Convert the camera intrinsic matrix to float32.
+
+        Returns:
+          npt.NDArray[np.float32]: Camera intrinsic matrix.
+        """
+
+        return self.cam2img.astype(np.float32)
+
+    @property
+    def image_sensor_to_ego_pose_matrix_fp32(self) -> npt.NDArray[np.float32]:
+        """
+        Convert the image sensor to ego pose matrix to float32.
+
+        Returns:
+          npt.NDArray[np.float32]: Image sensor to ego pose matrix.
+        """
+
+        return self.image_sensor_to_ego_pose_matrix.astype(np.float32)
+
+    @property
+    def image_frame_ego_pose_to_global_matrix_fp32(self) -> npt.NDArray[np.float32]:
+        """
+        Convert the image frame ego pose to global matrix to float32.
+
+        Returns:
+          npt.NDArray[np.float32]: Image frame ego pose to global matrix.
+        """
+
+        return self.image_frame_ego_pose_to_global_matrix.astype(np.float32)
+
+    @property
+    def lidar2cam_fp32(self) -> npt.NDArray[np.float32]:
+        """
+        Convert the lidar2cam matrix to float32.
+
+        Returns:
+          npt.NDArray[np.float32]: Lidar to camera transformation matrix.
+        """
+
+        return self.lidar2cam.astype(np.float32)
+
+    @property
+    def lidar2img_fp32(self) -> npt.NDArray[np.float32] | None:
+        """
+        Convert the lidar2img projection matrix to float32 if available.
+
+        Returns:
+          npt.NDArray[np.float32] | None: Lidar to image projection matrix.
+        """
+
+        if self.lidar2img is None:
+            return None
+        return self.lidar2img.astype(np.float32)
+
+    def to_dictionary(self) -> Mapping[str, Any]:
+        """
+        Convert the image frame data model to a dictionary.
+
+        Returns:
+          Mapping[str, Any]: Dictionary representation of the image frame data model.
+        """
+
+        return {
+            ImageFrameDatasetSchema.image_frame_id.name: self.image_frame_id,
+            ImageFrameDatasetSchema.image_sensor_id.name: self.image_sensor_id,
+            ImageFrameDatasetSchema.image_sensor_channel_name.name: self.image_sensor_channel_name,
+            ImageFrameDatasetSchema.image_timestamp_seconds.name: self.image_timestamp_seconds,
+            ImageFrameDatasetSchema.image_path.name: self.image_path,
+            ImageFrameDatasetSchema.image_height.name: self.image_height,
+            ImageFrameDatasetSchema.image_width.name: self.image_width,
+            ImageFrameDatasetSchema.cam2img.name: self.cam2img_fp32,
+            ImageFrameDatasetSchema.image_sensor_to_ego_pose_matrix.name: self.image_sensor_to_ego_pose_matrix_fp32,
+            ImageFrameDatasetSchema.image_frame_ego_pose_to_global_matrix.name: self.image_frame_ego_pose_to_global_matrix_fp32,
+            ImageFrameDatasetSchema.lidar2cam.name: self.lidar2cam_fp32,
+            ImageFrameDatasetSchema.lidar2img.name: self.lidar2img_fp32,
+        }
+
+    @classmethod
+    def load_from_dictionary(cls, data_model: Mapping[str, Any]) -> ImageFrameDataModel:
+        """
+        Load the image frame data model and decode it to the corresponding ImageFrameDataModel
+        from a dictionary, which is deserialized from a Polars dataframe.
+
+        Args:
+          data_model: Dictionary representation of the image frame data model, which is
+          deserialized from a Polars dataframe.
+
+        Returns:
+          ImageFrameDataModel: ImageFrameDataModel object.
+        """
+
+        raw_lidar2img = data_model.get(ImageFrameDatasetSchema.lidar2img.name)
+
+        return cls(
+            image_frame_id=data_model[ImageFrameDatasetSchema.image_frame_id.name],
+            image_sensor_id=data_model[ImageFrameDatasetSchema.image_sensor_id.name],
+            image_sensor_channel_name=data_model[
+                ImageFrameDatasetSchema.image_sensor_channel_name.name
+            ],
+            image_timestamp_seconds=data_model[
+                ImageFrameDatasetSchema.image_timestamp_seconds.name
+            ],
+            image_path=data_model[ImageFrameDatasetSchema.image_path.name],
+            image_height=data_model[ImageFrameDatasetSchema.image_height.name],
+            image_width=data_model[ImageFrameDatasetSchema.image_width.name],
+            cam2img=np.asarray(
+                data_model[ImageFrameDatasetSchema.cam2img.name], dtype=np.float64
+            ),
+            image_sensor_to_ego_pose_matrix=np.asarray(
+                data_model[ImageFrameDatasetSchema.image_sensor_to_ego_pose_matrix.name],
+                dtype=np.float64,
+            ),
+            image_frame_ego_pose_to_global_matrix=np.asarray(
+                data_model[ImageFrameDatasetSchema.image_frame_ego_pose_to_global_matrix.name],
+                dtype=np.float64,
+            ),
+            lidar2cam=np.asarray(
+                data_model[ImageFrameDatasetSchema.lidar2cam.name],
+                dtype=np.float64,
+            ),
+            lidar2img=(
+                np.asarray(raw_lidar2img, dtype=np.float64)
+                if raw_lidar2img is not None
+                else None
+            ),
+        )

--- a/autoware_ml/databases/schemas/image_frames.py
+++ b/autoware_ml/databases/schemas/image_frames.py
@@ -36,6 +36,7 @@ class ImageFrameDatasetSchema(BaseFieldSchema):
     """
 
     image_frame_id = DatasetTableColumn("image_frame_id", pl.String)
+    image_keyframe = DatasetTableColumn("image_keyframe", pl.Boolean)
     image_sensor_id = DatasetTableColumn("image_sensor_id", pl.String)
     image_sensor_channel_name = DatasetTableColumn("image_sensor_channel_name", pl.String)
     image_timestamp_seconds = DatasetTableColumn("image_timestamp_seconds", pl.Float64)
@@ -60,6 +61,8 @@ class ImageFrameDataModel(BaseModel, DataModelInterface):
 
     Attributes:
       image_frame_id: Image frame ID (sample data token).
+      image_keyframe: Whether this sample_data record is a keyframe in the original T4Dataset
+        annotation.
       image_sensor_id: Image sensor ID (calibrated sensor token).
       image_sensor_channel_name: Image sensor channel name, e.g. CAM_FRONT.
       image_timestamp_seconds: Image timestamp in seconds.
@@ -71,13 +74,15 @@ class ImageFrameDataModel(BaseModel, DataModelInterface):
         to the ego pose of this image frame.
       image_frame_ego_pose_to_global_matrix: Transformation matrix from the ego pose of this
         image frame to the global frame.
-      lidar2cam: Transformation matrix from LiDAR frame to camera frame (4, 4).
+      lidar2cam: Transformation matrix from LiDAR frame to camera frame (4, 4). Set to None if
+        unavailable (e.g. for image sweeps, which are not associated with a specific lidar keyframe).
       lidar2img: Projection matrix from LiDAR frame to image plane (4, 4). Set to None if unavailable.
     """
 
     model_config = ConfigDict(frozen=True, strict=True, arbitrary_types_allowed=True)
 
     image_frame_id: str
+    image_keyframe: bool
     image_sensor_id: str
     image_sensor_channel_name: str
     image_timestamp_seconds: float
@@ -87,7 +92,7 @@ class ImageFrameDataModel(BaseModel, DataModelInterface):
     cam2img: npt.NDArray[np.float64]  # (3, 3)
     image_sensor_to_ego_pose_matrix: npt.NDArray[np.float64]  # (4, 4)
     image_frame_ego_pose_to_global_matrix: npt.NDArray[np.float64]  # (4, 4)
-    lidar2cam: npt.NDArray[np.float64]  # (4, 4)
+    lidar2cam: npt.NDArray[np.float64] | None  # (4, 4) or None
     lidar2img: npt.NDArray[np.float64] | None  # (4, 4) or None
 
     @property
@@ -124,14 +129,16 @@ class ImageFrameDataModel(BaseModel, DataModelInterface):
         return self.image_frame_ego_pose_to_global_matrix.astype(np.float32)
 
     @property
-    def lidar2cam_fp32(self) -> npt.NDArray[np.float32]:
+    def lidar2cam_fp32(self) -> npt.NDArray[np.float32] | None:
         """
-        Convert the lidar2cam matrix to float32.
+        Convert the lidar2cam matrix to float32 if available.
 
         Returns:
-          npt.NDArray[np.float32]: Lidar to camera transformation matrix.
+          npt.NDArray[np.float32] | None: Lidar to camera transformation matrix.
         """
 
+        if self.lidar2cam is None:
+            return None
         return self.lidar2cam.astype(np.float32)
 
     @property
@@ -157,6 +164,7 @@ class ImageFrameDataModel(BaseModel, DataModelInterface):
 
         return {
             ImageFrameDatasetSchema.image_frame_id.name: self.image_frame_id,
+            ImageFrameDatasetSchema.image_keyframe.name: self.image_keyframe,
             ImageFrameDatasetSchema.image_sensor_id.name: self.image_sensor_id,
             ImageFrameDatasetSchema.image_sensor_channel_name.name: self.image_sensor_channel_name,
             ImageFrameDatasetSchema.image_timestamp_seconds.name: self.image_timestamp_seconds,
@@ -184,10 +192,12 @@ class ImageFrameDataModel(BaseModel, DataModelInterface):
           ImageFrameDataModel: ImageFrameDataModel object.
         """
 
+        raw_lidar2cam = data_model.get(ImageFrameDatasetSchema.lidar2cam.name)
         raw_lidar2img = data_model.get(ImageFrameDatasetSchema.lidar2img.name)
 
         return cls(
             image_frame_id=data_model[ImageFrameDatasetSchema.image_frame_id.name],
+            image_keyframe=data_model[ImageFrameDatasetSchema.image_keyframe.name],
             image_sensor_id=data_model[ImageFrameDatasetSchema.image_sensor_id.name],
             image_sensor_channel_name=data_model[
                 ImageFrameDatasetSchema.image_sensor_channel_name.name
@@ -209,9 +219,8 @@ class ImageFrameDataModel(BaseModel, DataModelInterface):
                 data_model[ImageFrameDatasetSchema.image_frame_ego_pose_to_global_matrix.name],
                 dtype=np.float64,
             ),
-            lidar2cam=np.asarray(
-                data_model[ImageFrameDatasetSchema.lidar2cam.name],
-                dtype=np.float64,
+            lidar2cam=(
+                np.asarray(raw_lidar2cam, dtype=np.float64) if raw_lidar2cam is not None else None
             ),
             lidar2img=(
                 np.asarray(raw_lidar2img, dtype=np.float64)

--- a/autoware_ml/databases/schemas/image_frames.py
+++ b/autoware_ml/databases/schemas/image_frames.py
@@ -75,7 +75,7 @@ class ImageFrameDataModel(BaseModel, DataModelInterface):
       image_frame_ego_pose_to_global_matrix: Transformation matrix from the ego pose of this
         image frame to the global frame.
       lidar2cam: Transformation matrix from LiDAR frame to camera frame (4, 4). Set to None if
-        unavailable (e.g. for image sweeps, which are not associated with a specific lidar keyframe).
+        unavailable.
       lidar2img: Projection matrix from LiDAR frame to image plane (4, 4). Set to None if unavailable.
     """
 

--- a/autoware_ml/databases/t4dataset/t4records_generator.py
+++ b/autoware_ml/databases/t4dataset/t4records_generator.py
@@ -651,6 +651,73 @@ class T4RecordsGenerator:
                 lidar2img=lidar2img,
             )
 
+    def _extract_image_sweeps(
+        self, sample: Sample, camera_channel_name: str, lidar_channel_name: str
+    ) -> Sequence[ImageFrameDataModel]:
+        """
+        Extract multi-sweep image metadata (past camera keyframes) from a T4 Sample, for
+        sequence-based models. Unlike _extract_lidar_sweeps, this walks the sample.prev chain
+        (keyframe-to-keyframe) rather than the per-sensor sample_data.prev chain, since camera and
+        lidar sample_data are not directly linked to each other outside of a shared sample. Walking
+        sample.prev guarantees each image sweep is naturally paired with a lidar frame captured at
+        the same sample, so lidar2cam/lidar2img can be computed for every sweep exactly like the
+        current image frame.
+
+        Args:
+          sample: T4 Sample to walk backwards from.
+          camera_channel_name: Camera channel name.
+          lidar_channel_name: Lidar channel name.
+
+        Returns:
+          Sequence[ImageFrameDataModel]: Image sweep data models, ordered from most recent to
+            oldest.
+        """
+
+        image_sweep_data_models = []
+        current_sample = sample
+
+        for _ in range(self.max_sweeps):
+            if not current_sample.prev:
+                break
+
+            current_sample: Sample = self.t4_devkit_dataset.get(
+                SchemaName.SAMPLE, current_sample.prev
+            )
+            if camera_channel_name not in current_sample.data:
+                break
+            if lidar_channel_name not in current_sample.data:
+                break
+
+            current_lidar_sd_record: SampleData = self.t4_devkit_dataset.get(
+                SchemaName.SAMPLE_DATA, current_sample.data[lidar_channel_name]
+            )
+            current_lidar_cs_record: CalibratedSensor = self.t4_devkit_dataset.get(
+                SchemaName.CALIBRATED_SENSOR, current_lidar_sd_record.calibrated_sensor_token
+            )
+            current_lidar_sensor_to_ego_pose_matrix = convert_quaternion_to_matrix(
+                rotation_quaternion=current_lidar_cs_record.rotation,
+                translation=current_lidar_cs_record.translation,
+                convert_to_float32=False,
+            )
+            current_lidar_ego_pose_record: EgoPose = self.t4_devkit_dataset.get(
+                SchemaName.EGO_POSE, current_lidar_sd_record.ego_pose_token
+            )
+            current_lidar_frame_ego_pose_to_global_matrix = convert_quaternion_to_matrix(
+                rotation_quaternion=current_lidar_ego_pose_record.rotation,
+                translation=current_lidar_ego_pose_record.translation,
+                convert_to_float32=False,
+            )
+
+            image_sweep_data_models.append(
+                self._extract_image_frame(
+                    sample=current_sample,
+                    camera_channel_name=camera_channel_name,
+                    lidar_sensor_to_ego_pose_matrix=current_lidar_sensor_to_ego_pose_matrix,
+                    lidar_frame_ego_pose_to_global_matrix=current_lidar_frame_ego_pose_to_global_matrix,
+                )
+            )
+        return image_sweep_data_models
+
     def _extract_category_mapping(self) -> CategoryMappingDataModel:
         """
         Extract category metadata from a T4 Sample.
@@ -784,15 +851,20 @@ class T4RecordsGenerator:
 
         # 5) Extract image frames information from the T4Dataset
         camera_channel_names = self._extract_camera_channel_names(sample=sample)
-        image_frame_data_models = [
-            self._extract_image_frame(
+        image_frame_data_models = []
+        for camera_channel_name in camera_channel_names:
+            image_frame_data_model = self._extract_image_frame(
                 sample=sample,
                 camera_channel_name=camera_channel_name,
                 lidar_sensor_to_ego_pose_matrix=lidar_frame_data_model.lidar_sensor_to_ego_pose_matrix,
                 lidar_frame_ego_pose_to_global_matrix=lidar_frame_data_model.lidar_frame_ego_pose_to_global_matrix,
             )
-            for camera_channel_name in camera_channel_names
-        ]
+            image_sweep_data_models = self._extract_image_sweeps(
+                sample=sample,
+                camera_channel_name=camera_channel_name,
+                lidar_channel_name=lidar_channel_name,
+            )
+            image_frame_data_models.extend([image_frame_data_model] + image_sweep_data_models)
 
         # 6) Extract category information from the T4Dataset
         category_mapping_data_model = self._extract_category_mapping()

--- a/autoware_ml/databases/t4dataset/t4records_generator.py
+++ b/autoware_ml/databases/t4dataset/t4records_generator.py
@@ -41,6 +41,7 @@ from autoware_ml.databases.schemas.frame_basic_metadata import FrameBasicMetadat
 from autoware_ml.databases.schemas.dataset_schemas import DatasetRecord
 from autoware_ml.databases.schemas.lidar_frames import LidarFrameDataModel
 from autoware_ml.databases.schemas.lidar_sources import LidarSourceDataModel
+from autoware_ml.databases.schemas.image_frames import ImageFrameDataModel
 from autoware_ml.databases.schemas.category_mapping import CategoryMappingDataModel
 from autoware_ml.databases.schemas.box3d_schemas import Box3DDataModel, Box3DDatasetSchema
 from autoware_ml.databases.scenarios import ScenarioData
@@ -546,6 +547,110 @@ class T4RecordsGenerator:
 
         return lidar_source_data_models
 
+    def _extract_camera_channel_names(self, sample: Sample) -> Sequence[str]:
+        """
+        Extract camera channel names present in a T4 sample.
+
+        Args:
+          sample: T4 Sample.
+
+        Returns:
+          Sequence[str]: Sequence of camera channel names in the sample.
+        """
+
+        camera_channel_names = []
+        for channel_name, sample_data_token in sample.data.items():
+            sd_record: SampleData = self.t4_devkit_dataset.get(
+                SchemaName.SAMPLE_DATA, sample_data_token
+            )
+            cs_record: CalibratedSensor = self.t4_devkit_dataset.get(
+                SchemaName.CALIBRATED_SENSOR, sd_record.calibrated_sensor_token
+            )
+            sensor_record: Sensor = self.t4_devkit_dataset.get(
+                SchemaName.SENSOR, cs_record.sensor_token
+            )
+            modality = getattr(sensor_record, self.__MODALITY_STRING, None)
+            modality_value = getattr(modality, self.__VALUE_STRING, None)
+            if modality_value == Modality.CAMERA:
+                camera_channel_names.append(channel_name)
+
+        return camera_channel_names
+
+    def _extract_image_frame(
+            self,
+            sample: Sample,
+            camera_channel_name: str,
+            lidar_sensor_to_ego_pose_matrix: npt.NDArray[np.float64],
+            lidar_frame_ego_pose_to_global_matrix: npt.NDArray[np.float64],
+        ) -> ImageFrameDataModel:
+            """
+            Extract image frame from a T4 sample.
+
+            Args:
+              sample: T4 Sample.
+              camera_channel_name: Camera channel name.
+              lidar_sensor_to_ego_pose_matrix: Transformation matrix from LiDAR sensor to ego pose.
+              lidar_frame_ego_pose_to_global_matrix: Transformation matrix from LiDAR ego pose to global.
+
+            Returns:
+              ImageFrameDataModel: Image frame data model of the T4 sample.
+            """
+
+            calibrated_camera_sample_data_token = sample.data[camera_channel_name]
+            sd_record: SampleData = self.t4_devkit_dataset.get(
+                SchemaName.SAMPLE_DATA, calibrated_camera_sample_data_token
+            )
+            cs_record: CalibratedSensor = self.t4_devkit_dataset.get(
+                SchemaName.CALIBRATED_SENSOR, sd_record.calibrated_sensor_token
+            )
+            image_sensor_to_ego_matrix = convert_quaternion_to_matrix(
+                rotation_quaternion=cs_record.rotation,
+                translation=cs_record.translation,
+                convert_to_float32=False,
+            )
+
+            ego_pose_record: EgoPose = self.t4_devkit_dataset.get(
+                SchemaName.EGO_POSE, sd_record.ego_pose_token
+            )
+            image_frame_ego_pose_to_global_matrix = convert_quaternion_to_matrix(
+                rotation_quaternion=ego_pose_record.rotation,
+                translation=ego_pose_record.translation,
+                convert_to_float32=False,
+            )
+
+            image_path = self.t4_devkit_dataset.get_sample_data_path(
+                sample_data_token=calibrated_camera_sample_data_token
+            )
+
+            cam2img = np.asarray(cs_record.camera_intrinsic, dtype=np.float64)
+
+            # 1. 计算 lidar2cam 变换矩阵 (4x4)
+            cam2global = image_frame_ego_pose_to_global_matrix @ image_sensor_to_ego_matrix
+            global2cam = np.linalg.inv(cam2global)
+            lidar2global = lidar_frame_ego_pose_to_global_matrix @ lidar_sensor_to_ego_pose_matrix
+            lidar2cam = global2cam @ lidar2global
+
+            # 2. 计算 lidar2img 投影矩阵 (4x4)
+            cam2img_4x4 = np.eye(4, dtype=np.float64)
+            cam2img_4x4[:3, :3] = cam2img
+            lidar2img = cam2img_4x4 @ lidar2cam
+
+            return ImageFrameDataModel(
+                image_frame_id=calibrated_camera_sample_data_token,
+                image_keyframe=sd_record.is_key_frame,
+                image_sensor_id=cs_record.token,
+                image_sensor_channel_name=camera_channel_name,
+                image_timestamp_seconds=microseconds2seconds(sd_record.timestamp),
+                image_path=image_path,
+                image_height=sd_record.height,
+                image_width=sd_record.width,
+                cam2img=cam2img,
+                image_sensor_to_ego_pose_matrix=image_sensor_to_ego_matrix,
+                image_frame_ego_pose_to_global_matrix=image_frame_ego_pose_to_global_matrix,
+                lidar2cam=lidar2cam,
+                lidar2img=lidar2img,
+            )
+
     def _extract_category_mapping(self) -> CategoryMappingDataModel:
         """
         Extract category metadata from a T4 Sample.
@@ -677,13 +782,26 @@ class T4RecordsGenerator:
         # 4) Extract lidar sources information from the T4Dataset
         lidar_source_data_models = self._extract_lidar_sources()
 
-        # 5) Extract category information from the T4Dataset
+        # 5) Extract image frames information from the T4Dataset
+        camera_channel_names = self._extract_camera_channel_names(sample=sample)
+        image_frame_data_models = [
+            self._extract_image_frame(
+                sample=sample,
+                camera_channel_name=camera_channel_name,
+                lidar_sensor_to_ego_pose_matrix=lidar_frame_data_model.lidar_sensor_to_ego_pose_matrix,
+                lidar_frame_ego_pose_to_global_matrix=lidar_frame_data_model.lidar_frame_ego_pose_to_global_matrix,
+            )
+            for camera_channel_name in camera_channel_names
+        ]
+
+        # 6) Extract category information from the T4Dataset
         category_mapping_data_model = self._extract_category_mapping()
 
         return T4SampleRecord(
             frame_basic_metadata=frame_basic_metadata,
             lidar_frame_data_models=lidar_frame_data_models,
             lidar_source_data_models=lidar_source_data_models,
+            image_frame_data_models=image_frame_data_models,
             category_mapping_data_model=category_mapping_data_model,
             boxes_3d_data_model=boxes_3d_data_model,
         )

--- a/autoware_ml/databases/t4dataset/t4records_generator.py
+++ b/autoware_ml/databases/t4dataset/t4records_generator.py
@@ -624,13 +624,11 @@ class T4RecordsGenerator:
 
             cam2img = np.asarray(cs_record.camera_intrinsic, dtype=np.float64)
 
-            # 1. 计算 lidar2cam 变换矩阵 (4x4)
             cam2global = image_frame_ego_pose_to_global_matrix @ image_sensor_to_ego_matrix
             global2cam = np.linalg.inv(cam2global)
             lidar2global = lidar_frame_ego_pose_to_global_matrix @ lidar_sensor_to_ego_pose_matrix
             lidar2cam = global2cam @ lidar2global
 
-            # 2. 计算 lidar2img 投影矩阵 (4x4)
             cam2img_4x4 = np.eye(4, dtype=np.float64)
             cam2img_4x4[:3, :3] = cam2img
             lidar2img = cam2img_4x4 @ lidar2cam

--- a/autoware_ml/databases/t4dataset/t4records_generator.py
+++ b/autoware_ml/databases/t4dataset/t4records_generator.py
@@ -656,12 +656,7 @@ class T4RecordsGenerator:
     ) -> Sequence[ImageFrameDataModel]:
         """
         Extract multi-sweep image metadata (past camera keyframes) from a T4 Sample, for
-        sequence-based models. Unlike _extract_lidar_sweeps, this walks the sample.prev chain
-        (keyframe-to-keyframe) rather than the per-sensor sample_data.prev chain, since camera and
-        lidar sample_data are not directly linked to each other outside of a shared sample. Walking
-        sample.prev guarantees each image sweep is naturally paired with a lidar frame captured at
-        the same sample, so lidar2cam/lidar2img can be computed for every sweep exactly like the
-        current image frame.
+        sequence-based models.It walks the sample.prev chain(keyframe-to-keyframe). 
 
         Args:
           sample: T4 Sample to walk backwards from.

--- a/autoware_ml/databases/t4dataset/t4records_generator.py
+++ b/autoware_ml/databases/t4dataset/t4records_generator.py
@@ -19,6 +19,7 @@ from typing import Sequence, Tuple
 
 import numpy as np
 import numpy.typing as npt
+from PIL import Image
 from t4_devkit import Tier4
 from t4_devkit.dataclass.box import Box3D
 from t4_devkit.schema import (
@@ -622,6 +623,12 @@ class T4RecordsGenerator:
                 sample_data_token=calibrated_camera_sample_data_token
             )
 
+            image_height = sd_record.height
+            image_width = sd_record.width
+            if image_height is None or image_width is None:
+                with Image.open(image_path) as image:
+                    image_width, image_height = image.size
+
             cam2img = np.asarray(cs_record.camera_intrinsic, dtype=np.float64)
 
             cam2global = image_frame_ego_pose_to_global_matrix @ image_sensor_to_ego_matrix
@@ -640,8 +647,8 @@ class T4RecordsGenerator:
                 image_sensor_channel_name=camera_channel_name,
                 image_timestamp_seconds=microseconds2seconds(sd_record.timestamp),
                 image_path=image_path,
-                image_height=sd_record.height,
-                image_width=sd_record.width,
+                image_height=image_height,
+                image_width=image_width,
                 cam2img=cam2img,
                 image_sensor_to_ego_pose_matrix=image_sensor_to_ego_matrix,
                 image_frame_ego_pose_to_global_matrix=image_frame_ego_pose_to_global_matrix,
@@ -649,24 +656,52 @@ class T4RecordsGenerator:
                 lidar2img=lidar2img,
             )
 
-    def _extract_image_sweeps(
-        self, sample: Sample, camera_channel_name: str, lidar_channel_name: str
+    def _extract_image_channel_frames(
+        self, sample: Sample, lidar_frame_data_model: LidarFrameDataModel
     ) -> Sequence[ImageFrameDataModel]:
         """
-        Extract multi-sweep image metadata (past camera keyframes) from a T4 Sample, for
-        sequence-based models.It walks the sample.prev chain(keyframe-to-keyframe). 
+        Extract the current-frame image metadata for all camera channels of a T4 Sample.
+
+        Args:
+          sample: T4 Sample.
+          lidar_frame_data_model: Lidar frame data model of the current T4 sample, used to
+            compute lidar2cam / lidar2img projections for each camera channel.
+
+        Returns:
+          Sequence[ImageFrameDataModel]: Image frame data models of all camera channels present
+            in the current T4 sample.
+        """
+
+        camera_channel_names = self._extract_camera_channel_names(sample=sample)
+
+        return [
+            self._extract_image_frame(
+                sample=sample,
+                camera_channel_name=camera_channel_name,
+                lidar_sensor_to_ego_pose_matrix=lidar_frame_data_model.lidar_sensor_to_ego_pose_matrix,
+                lidar_frame_ego_pose_to_global_matrix=lidar_frame_data_model.lidar_frame_ego_pose_to_global_matrix,
+            )
+            for camera_channel_name in camera_channel_names
+        ]
+
+    def _extract_image_channel_sweeps(
+        self, sample: Sample, lidar_channel_name: str
+    ) -> Sequence[Sequence[ImageFrameDataModel]]:
+        """
+        Extract multi-sweep image metadata (past camera keyframes, all channels) from a T4
+        Sample, for sequence-based models. It walks the sample.prev chain (keyframe-to-keyframe).
 
         Args:
           sample: T4 Sample to walk backwards from.
-          camera_channel_name: Camera channel name.
           lidar_channel_name: Lidar channel name.
 
         Returns:
-          Sequence[ImageFrameDataModel]: Image sweep data models, ordered from most recent to
-            oldest.
+          Sequence[Sequence[ImageFrameDataModel]]: Image sweep data models, ordered from most
+            recent to oldest. Each item is the list of image frame data models across all camera
+            channels present at that sweep offset.
         """
 
-        image_sweep_data_models = []
+        image_channel_sweep_data_models = []
         current_sample = sample
 
         for _ in range(self.max_sweeps):
@@ -676,8 +711,6 @@ class T4RecordsGenerator:
             current_sample: Sample = self.t4_devkit_dataset.get(
                 SchemaName.SAMPLE, current_sample.prev
             )
-            if camera_channel_name not in current_sample.data:
-                break
             if lidar_channel_name not in current_sample.data:
                 break
 
@@ -701,15 +734,20 @@ class T4RecordsGenerator:
                 convert_to_float32=False,
             )
 
-            image_sweep_data_models.append(
-                self._extract_image_frame(
-                    sample=current_sample,
-                    camera_channel_name=camera_channel_name,
-                    lidar_sensor_to_ego_pose_matrix=current_lidar_sensor_to_ego_pose_matrix,
-                    lidar_frame_ego_pose_to_global_matrix=current_lidar_frame_ego_pose_to_global_matrix,
-                )
+            camera_channel_names = self._extract_camera_channel_names(sample=current_sample)
+
+            image_channel_sweep_data_models.append(
+                [
+                    self._extract_image_frame(
+                        sample=current_sample,
+                        camera_channel_name=camera_channel_name,
+                        lidar_sensor_to_ego_pose_matrix=current_lidar_sensor_to_ego_pose_matrix,
+                        lidar_frame_ego_pose_to_global_matrix=current_lidar_frame_ego_pose_to_global_matrix,
+                    )
+                    for camera_channel_name in camera_channel_names
+                ]
             )
-        return image_sweep_data_models
+        return image_channel_sweep_data_models
 
     def _extract_category_mapping(self) -> CategoryMappingDataModel:
         """
@@ -843,21 +881,17 @@ class T4RecordsGenerator:
         lidar_source_data_models = self._extract_lidar_sources()
 
         # 5) Extract image frames information from the T4Dataset
-        camera_channel_names = self._extract_camera_channel_names(sample=sample)
-        image_frame_data_models = []
-        for camera_channel_name in camera_channel_names:
-            image_frame_data_model = self._extract_image_frame(
-                sample=sample,
-                camera_channel_name=camera_channel_name,
-                lidar_sensor_to_ego_pose_matrix=lidar_frame_data_model.lidar_sensor_to_ego_pose_matrix,
-                lidar_frame_ego_pose_to_global_matrix=lidar_frame_data_model.lidar_frame_ego_pose_to_global_matrix,
-            )
-            image_sweep_data_models = self._extract_image_sweeps(
-                sample=sample,
-                camera_channel_name=camera_channel_name,
-                lidar_channel_name=lidar_channel_name,
-            )
-            image_frame_data_models.extend([image_frame_data_model] + image_sweep_data_models)
+        image_channel_frame_data_models = self._extract_image_channel_frames(
+            sample=sample, lidar_frame_data_model=lidar_frame_data_model
+        )
+        image_channel_sweep_data_models = self._extract_image_channel_sweeps(
+            sample=sample, lidar_channel_name=lidar_channel_name
+        )
+
+        # Concat image channel frame data models and image channel sweep data models
+        image_frame_data_models = [
+            image_channel_frame_data_models
+        ] + image_channel_sweep_data_models
 
         # 6) Extract category information from the T4Dataset
         category_mapping_data_model = self._extract_category_mapping()

--- a/autoware_ml/databases/t4dataset/t4sample_records.py
+++ b/autoware_ml/databases/t4dataset/t4sample_records.py
@@ -21,6 +21,7 @@ from autoware_ml.databases.schemas.frame_basic_metadata import FrameBasicMetadat
 from autoware_ml.databases.schemas.dataset_schemas import DatasetRecord
 from autoware_ml.databases.schemas.lidar_frames import LidarFrameDataModel
 from autoware_ml.databases.schemas.lidar_sources import LidarSourceDataModel
+from autoware_ml.databases.schemas.image_frames import ImageFrameDataModel
 from autoware_ml.databases.schemas.category_mapping import CategoryMappingDataModel
 
 
@@ -32,6 +33,7 @@ class T4SampleRecord(BaseModel):
     frame_basic_metadata: FrameBasicMetadata
     lidar_frame_data_models: Sequence[LidarFrameDataModel]
     lidar_source_data_models: Sequence[LidarSourceDataModel]
+    image_frame_data_models: Sequence[ImageFrameDataModel]
     category_mapping_data_model: CategoryMappingDataModel
     boxes_3d_data_model: Sequence[Box3DDataModel]
 
@@ -53,6 +55,7 @@ class T4SampleRecord(BaseModel):
             vehicle_type=self.frame_basic_metadata.vehicle_type,
             lidar_frames=self.lidar_frame_data_models,
             lidar_sources=self.lidar_source_data_models,
+            image_frames=self.image_frame_data_models,
             category_mapping=self.category_mapping_data_model,
             boxes_3d=self.boxes_3d_data_model,
         )

--- a/autoware_ml/databases/t4dataset/t4sample_records.py
+++ b/autoware_ml/databases/t4dataset/t4sample_records.py
@@ -33,7 +33,7 @@ class T4SampleRecord(BaseModel):
     frame_basic_metadata: FrameBasicMetadata
     lidar_frame_data_models: Sequence[LidarFrameDataModel]
     lidar_source_data_models: Sequence[LidarSourceDataModel]
-    image_frame_data_models: Sequence[ImageFrameDataModel]
+    image_frame_data_models: Sequence[Sequence[ImageFrameDataModel]]
     category_mapping_data_model: CategoryMappingDataModel
     boxes_3d_data_model: Sequence[Box3DDataModel]
 

--- a/autoware_ml/types/sensor.py
+++ b/autoware_ml/types/sensor.py
@@ -27,3 +27,35 @@ class LidarChannel(str, Enum):
 
     LIDAR_TOP = "LIDAR_TOP"
     LIDAR_CONCAT = "LIDAR_CONCAT"
+
+
+class CameraChannel(str, Enum):
+    """
+    Camera channel in Dataset.
+
+    Attributes:
+      CAM_FRONT: Front camera channel.
+      CAM_FRONT_RIGHT: Front right camera channel.
+      CAM_FRONT_LEFT: Front left camera channel.
+      CAM_BACK: Back camera channel.
+      CAM_BACK_LEFT: Back left camera channel.
+      CAM_BACK_RIGHT: Back right camera channel.
+      CAM_FRONT_WIDE: Front wide camera channel.
+      CAM_FRONT_LEFT_WIDE: Front left wide camera channel.
+      CAM_FRONT_RIGHT_WIDE: Front right wide camera channel.
+      CAM_BACK_LEFT_WIDE: Back left wide camera channel.
+      CAM_BACK_RIGHT_WIDE: Back right wide camera channel.
+    """
+
+    CAM_FRONT = "CAM_FRONT"
+    CAM_FRONT_RIGHT = "CAM_FRONT_RIGHT"
+    CAM_FRONT_LEFT = "CAM_FRONT_LEFT"
+    CAM_BACK = "CAM_BACK"
+    CAM_BACK_LEFT = "CAM_BACK_LEFT"
+    CAM_BACK_RIGHT = "CAM_BACK_RIGHT"
+    # jpntaxigen2 wide camera channels
+    CAM_FRONT_WIDE = "CAM_FRONT_WIDE"
+    CAM_FRONT_LEFT_WIDE = "CAM_FRONT_LEFT_WIDE"
+    CAM_FRONT_RIGHT_WIDE = "CAM_FRONT_RIGHT_WIDE"
+    CAM_BACK_LEFT_WIDE = "CAM_BACK_LEFT_WIDE"
+    CAM_BACK_RIGHT_WIDE = "CAM_BACK_RIGHT_WIDE"


### PR DESCRIPTION
## Summary

Adds a 2D image frame schema to the T4Dataset database layer so camera metadata can be stored alongside the existing LiDAR frame/source records.

- Introduces ImageFrameDataModel 
   ` 'image_frames',
    List(
        Struct({
            'image_frame_id': String,
            'image_sensor_id': String,
            'image_sensor_channel_name': String,
            'image_timestamp_seconds': Float64,
            'image_path': String,
            'image_height': Int32,
            'image_width': Int32,
            'cam2img': Array(Float32, shape=(3, 3)),
            'image_sensor_to_ego_pose_matrix': Array(Float32, shape=(4, 4)),
            'image_frame_ego_pose_to_global_matrix': Array(Float32, shape=(4, 4)),
            'lidar2cam': Array(Float32, shape=(4, 4)),
            'lidar2img': Array(Float32, shape=(4, 4)),
        })
    ),`

- Adds CameraChannel enum.

- Extends T4RecordsGenerator with a new _extract_image_sweeps method that collects past camera sweeps for each keyframe,


## Related Issues

<!-- Link related issues or feature requests -->

## Checklist

- [ ] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [ ] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

## Additional Notes

<!-- Anything else reviewers should know? -->

The correctness of the generated parquet file is checked in [1](https://tier4.atlassian.net/wiki/spaces/~459732634/pages/5525799289/2D+data+schema?focusedCommentId=5525701171)

<!-- Any additional logs or information. -->

