### PR TITLE
feat(ptv3): export fused bf16 TransHead attention in all detection configs

### DIFF
--- a/autoware_ml/configs/tasks/detection3d/ptv3/voxel005_51m_nuscenes.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/voxel005_51m_nuscenes.yaml
@@ -163,6 +163,8 @@ model:
     num_decoder_layers: 1
     num_heads: 8
     feedforward_channels: 256
+    # Fusable bf16 cross-attention export; requires the fp16 module precision below and SM80+.
+    use_bf16_cross_attention: true
     common_heads:
       center: [2, 2]
       height: [1, 2]
@@ -210,6 +212,7 @@ deploy:
   onnx:
     modules:
       ptv3_det3d_head:
+        precision: fp16
         modify_graph:
           _target_: autoware_ml.utils.onnx_modifiers.TransHeadTensorRTModifier
           k: ${num_proposals}

--- a/autoware_ml/configs/tasks/detection3d/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
+++ b/autoware_ml/configs/tasks/detection3d/ptv3/voxel012_122m_t4dataset_j6gen2.yaml
@@ -178,6 +178,8 @@ model:
     num_decoder_layers: 1
     num_heads: 8
     feedforward_channels: 256
+    # Fusable bf16 cross-attention export; requires the fp16 module precision below and SM80+.
+    use_bf16_cross_attention: true
     common_heads:
       center: [2, 2]
       height: [1, 2]
@@ -242,6 +244,7 @@ deploy:
   onnx:
     modules:
       ptv3_det3d_head:
+        precision: fp16
         modify_graph:
           _target_: autoware_ml.utils.onnx_modifiers.TransHeadTensorRTModifier
           k: ${num_proposals}

--- a/autoware_ml/configs/tasks/multi/ptv3/base.yaml
+++ b/autoware_ml/configs/tasks/multi/ptv3/base.yaml
@@ -45,6 +45,8 @@ model:
     num_decoder_layers: 1
     num_heads: 8
     feedforward_channels: 256
+    # Fusable bf16 cross-attention export; requires the fp16 module precision below and SM80+.
+    use_bf16_cross_attention: true
     common_heads:
       center: [2, 2]
       height: [1, 2]
@@ -156,6 +158,7 @@ deploy:
           dec_depths: ${model.seg3d_head.dec_depths}
           class_names: ${seg_class_names:${dataset.segmentation3d.class_mapping}, ${dataset.segmentation3d.num_classes}}
       ptv3_det3d_head:
+        precision: fp16
         output_names: [dense_heatmap, query_heatmap_score, query_labels, heatmap, center, height, dim, rot]
         metainfo:
           bbox_voxel_size: ${model.bbox_head.bbox_coder.voxel_size}

--- a/autoware_ml/tests/configs/test_deploy_metainfo.py
+++ b/autoware_ml/tests/configs/test_deploy_metainfo.py
@@ -13,8 +13,11 @@ from autoware_ml.utils.deploy import merge_module_onnx_cfg
 
 PTV3_CONFIGS = [
     "tasks/multi/ptv3/voxel012_122m_t4dataset_j6gen2",
+    "tasks/multi/litept/voxel012_122m_t4dataset_j6gen2",
     "tasks/segmentation3d/ptv3/voxel012_122m_t4dataset_j6gen2",
+    "tasks/segmentation3d/litept/voxel012_122m_t4dataset_j6gen2",
     "tasks/detection3d/ptv3/voxel012_122m_t4dataset_j6gen2",
+    "tasks/detection3d/ptv3/voxel005_51m_nuscenes",
 ]
 DET_CONFIGS = [name for name in PTV3_CONFIGS if "segmentation3d" not in name]
 
@@ -56,3 +59,13 @@ def test_det_head_has_twist_follows_use_velocity(config_name: str) -> None:
     module_cfg = merge_module_onnx_cfg(cfg.deploy.onnx, "ptv3_det3d_head")
     assert isinstance(module_cfg.metainfo.has_twist, bool)
     assert module_cfg.metainfo.has_twist == cfg.model.bbox_head.use_velocity
+
+
+@pytest.mark.parametrize("config_name", DET_CONFIGS)
+def test_det_head_exports_fused_bf16_attention(config_name: str) -> None:
+    # The fused TransHead path needs the head flag and the fp16 module precision
+    # together; export refuses a mismatch, so every shipped config must pair them.
+    cfg = _compose(config_name)
+    module_cfg = merge_module_onnx_cfg(cfg.deploy.onnx, "ptv3_det3d_head")
+    assert cfg.model.bbox_head.use_bf16_cross_attention is True
+    assert module_cfg.precision == "fp16"

--- a/docs/models/ptv3.md
+++ b/docs/models/ptv3.md
@@ -95,8 +95,10 @@ autoware-ml deploy \
 The deployment command switches PTv3 attention blocks into non-flash export
 mode automatically.
 
-Transformer blocks in the detection head are not fused by default. Bf16 is required
-for numerically stable TensorRT operator fusion:
+Every shipped detection config, including the LitePT ones that inherit from
+`multi/ptv3`, exports the detection head with TensorRT-fusable attention. Bf16 is
+required for numerically stable operator fusion, so the configs pair the head flag
+with an fp16 precision for the detection-head module:
 
 ```yaml
 model:
@@ -104,12 +106,22 @@ model:
     use_bf16_cross_attention: true
 deploy:
   onnx:
-    precision: fp16
+    modules:
+      ptv3_det3d_head:
+        precision: fp16
 ```
 
-Both settings are required to enable the fused path, and the resulting model requires
-an SM80 or newer GPU. Without both settings, export uses the stable but slower non-fused
-attention path.
+Both settings are required to enable the fused path, and the resulting engine requires
+an SM80 or newer GPU. Export refuses to run with only one of them set. To fall back to
+the stable but slower non-fused attention path, disable both:
+
+```bash
+autoware-ml deploy \
+    --config-name detection3d/ptv3/voxel012_122m_t4dataset_j6gen2 \
+    --weights <checkpoint> \
+    model.bbox_head.use_bf16_cross_attention=false \
+    deploy.onnx.modules.ptv3_det3d_head.precision=fp32
+```
 
 The exported ONNX model returns both `pred_labels` and `pred_probs`. The
 probability output is produced by a final softmax layer, while training and


### PR DESCRIPTION
## Summary

Enables the TensorRT-fusable TransHead attention export from #95 in every PTv3-family config that has a detection head, including the LitePT ones.

- set `model.bbox_head.use_bf16_cross_attention: true` and `deploy.onnx.modules.ptv3_det3d_head.precision: fp16`.
- The fp16 precision is set on the `ptv3_det3d_head` module only. The encoder and segmentation head exports keep their current precision, so this PR changes nothing but the detection head.
- Docs: `docs/models/ptv3.md` now states that the shipped configs export the fused path and shows the override to fall back to the non-fused fp32 head.
- Test: `tests/configs/test_deploy_metainfo.py` gains a composition test asserting that every detection config pairs the head flag with the fp16 module precision, and its config list now also covers the nuScenes detection config and both LitePT configs.

## Related Issues

- Follow-up to #95 (fused mixed-precision TransHead attention) and #89 (`deploy.onnx.precision`).
- Covers the LitePT configs added in #94.

## Checklist

- [x] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [x] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

