### PR TITLE
fix(litept): look up split export specs under their deploy module names

### DIFF
--- a/autoware_ml/tests/models/test_litept.py
+++ b/autoware_ml/tests/models/test_litept.py
@@ -223,7 +223,7 @@ def test_litept_split_export_declares_and_consumes_the_ptv3_contract() -> None:
     batch = move_batch_to_device(build_inputs(), torch.device("cuda"))
 
     specs = model.build_export_specs(batch)
-    encoder_spec = specs["encoder"]
+    encoder_spec = specs["ptv3_encoder"]
 
     assert "serialized_code" in encoder_spec.input_param_names
     assert not any("_cluster" in name for name in encoder_spec.input_param_names)
@@ -235,7 +235,7 @@ def test_litept_split_export_declares_and_consumes_the_ptv3_contract() -> None:
         stage_feats = encoder_spec.module(*encoder_spec.args)
     assert len(stage_feats) == 3
 
-    head_spec = specs["seg3d_head"]
+    head_spec = specs["ptv3_seg3d_head"]
     # dec_depths is all zeros, so the head reduces to features plus clusters.
     assert head_spec.input_param_names == [
         "point_feat_0",
@@ -312,7 +312,7 @@ def test_exported_encoder_graph_declares_a_subset_of_the_contract(tmp_path) -> N
     for tag, model in (("litept", build_litept_seg_model()), ("ptv3", build_seg_model())):
         model = model.cuda().eval()
         batch = move_batch_to_device(build_inputs(), torch.device("cuda"))
-        spec = model.build_export_specs(batch)["encoder"]
+        spec = model.build_export_specs(batch)["ptv3_encoder"]
         path = tmp_path / f"{tag}_encoder.onnx"
 
         export_to_onnx(
@@ -340,8 +340,8 @@ def test_litept_encoder_contract_matches_ptv3_field_for_field() -> None:
     every stage, plus ``serialized_code`` - and rejects an engine missing any of them.
     """
     batch = move_batch_to_device(build_inputs(), torch.device("cuda"))
-    litept = build_litept_seg_model().cuda().eval().build_export_specs(batch)["encoder"]
-    ptv3 = build_seg_model().cuda().eval().build_export_specs(batch)["encoder"]
+    litept = build_litept_seg_model().cuda().eval().build_export_specs(batch)["ptv3_encoder"]
+    ptv3 = build_seg_model().cuda().eval().build_export_specs(batch)["ptv3_encoder"]
 
     def stage_fields(names: list[str]) -> set[str]:
         return {name.split("_", 3)[3] for name in names if name.startswith("serialized_pooling_")}


### PR DESCRIPTION
## Summary

Three LitePT tests fail on `main` with `KeyError: 'encoder'`. They look up the split export specs as `specs["encoder"]` and `specs["seg3d_head"]`, but `build_export_specs` has keyed them `ptv3_encoder` and `ptv3_seg3d_head` since #91 (the LitePT tests in #94 were written before that rename landed). This renames the keys in the tests. No model code changes.

## Related Issues

- Test breakage introduced by the overlap of #91 and #94.
- Unblocks verifying #85 against the LitePT tests.

## Checklist

- [x] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [x] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

## Additional Notes

Affected tests: `test_litept_split_export_declares_and_consumes_the_ptv3_contract`, `test_exported_encoder_graph_declares_a_subset_of_the_contract`, `test_litept_encoder_contract_matches_ptv3_field_for_field`.

## Additional Log and Media

In the project container: `autoware_ml/tests/models/test_litept.py` 28 passed (was 25 passed, 3 failed).
