### PR TITLE
perf(lovasz): iterate the present classes as a host list

### DIFF
--- a/autoware_ml/losses/segmentation3d/lovasz.py
+++ b/autoware_ml/losses/segmentation3d/lovasz.py
@@ -134,10 +134,11 @@ class LovaszLoss(_Loss):
             return (probabilities * 0.0).sum()
 
         losses = []
-        for class_index in labels.unique():
+        # One device->host copy for the class list; iterating the CUDA tensor
+        # directly would synchronise once per class, and every class listed here
+        # is present, so the old per-class emptiness check was redundant.
+        for class_index in labels.unique().tolist():
             foreground = (labels == class_index).type_as(probabilities)
-            if foreground.sum() == 0:
-                continue
             class_errors = (foreground - probabilities[:, class_index]).abs()
             class_errors, permutation = torch.sort(class_errors, descending=True)
             foreground = foreground[permutation]

--- a/autoware_ml/losses/segmentation3d/lovasz.py
+++ b/autoware_ml/losses/segmentation3d/lovasz.py
@@ -36,8 +36,10 @@ def _lovasz_grad(sorted_ground_truth: torch.Tensor) -> torch.Tensor:
     """
     point_count = len(sorted_ground_truth)
     foreground_total = sorted_ground_truth.sum()
-    intersection = foreground_total - sorted_ground_truth.float().cumsum(0)
-    union = foreground_total + (1 - sorted_ground_truth).float().cumsum(0)
+    # Keep the caller's floating dtype rather than forcing float32, so the loss
+    # also runs in float64 (gradcheck) and mixed precision without a dtype clash.
+    intersection = foreground_total - sorted_ground_truth.cumsum(0)
+    union = foreground_total + (1 - sorted_ground_truth).cumsum(0)
     jaccard = 1.0 - intersection / union
     if point_count > 1:
         jaccard[1:point_count] = jaccard[1:point_count] - jaccard[0:-1]
@@ -134,9 +136,7 @@ class LovaszLoss(_Loss):
             return (probabilities * 0.0).sum()
 
         losses = []
-        # One device->host copy for the class list; iterating the CUDA tensor
-        # directly would synchronise once per class, and every class listed here
-        # is present, so the old per-class emptiness check was redundant.
+        # `.tolist()` synchronized once. Omitting it would sync per iteration.
         for class_index in labels.unique().tolist():
             foreground = (labels == class_index).type_as(probabilities)
             class_errors = (foreground - probabilities[:, class_index]).abs()

--- a/autoware_ml/tests/losses/test_lovasz.py
+++ b/autoware_ml/tests/losses/test_lovasz.py
@@ -38,18 +38,45 @@ def _logits_for(probabilities: torch.Tensor) -> torch.Tensor:
 def test_hand_computed_two_class_example() -> None:
     """Three points, two classes, worked through by hand from the definition.
 
-    Class 0 (points 0 and 1): errors 0.1, 0.4, 0.2 -> sorted 0.4, 0.2, 0.1 with
-    foreground 1, 0, 1. Intersection after each prefix: 1, 1, 0; union: 2, 3, 3;
-    Jaccard loss: 1/2, 2/3, 1; its increments: 1/2, 1/6, 1/3.
-    Loss_0 = 0.4/2 + 0.2/6 + 0.1/3 = 4/15.
-    Class 1 (point 2): errors 0.1, 0.4, 0.2 -> sorted 0.4, 0.2, 0.1 with
-    foreground 0, 1, 0. Intersection: 1, 0, 0; union: 2, 2, 3; Jaccard loss:
-    1/2, 1, 1; increments 1/2, 1/2, 0. Loss_1 = 0.4/2 + 0.2/2 = 0.3.
+    Probabilities for class 0 are 0.9, 0.6, 0.2; labels are 0, 0, 1. For each
+    present class: take the errors ``|1[y = c] - p_c|``, sort them descending,
+    and after each prefix of the sorted order compute the Jaccard loss
+    ``1 - intersection / union`` between the prefix and the ground truth. The
+    class term is the dot product of the sorted errors with the increments of
+    that Jaccard loss.
+
+    Class 0 (ground truth: points 0 and 1)::
+
+        point               0     1     2
+        error               0.1   0.4   0.2
+        sorted (point)      1     2     0
+        sorted error        0.4   0.2   0.1
+        is foreground       1     0     1
+        intersection        1     1     0
+        union               2     3     3
+        Jaccard loss        1/2   2/3   1
+        increment           1/2   1/6   1/3
+
+        term = 0.4 * 1/2 + 0.2 * 1/6 + 0.1 * 1/3 = 4/15
+
+    Class 1 (ground truth: point 2; p_1 = 0.1, 0.4, 0.8)::
+
+        sorted (point)      1     2     0
+        sorted error        0.4   0.2   0.1
+        is foreground       0     1     0
+        intersection        1     0     0
+        union               2     2     3
+        Jaccard loss        1/2   1     1
+        increment           1/2   1/2   0
+
+        term = 0.4 * 1/2 + 0.2 * 1/2 + 0.1 * 0 = 3/10
+
+    The loss is the mean of the two terms.
     """
     probabilities = torch.tensor([[0.9, 0.1], [0.6, 0.4], [0.2, 0.8]], dtype=torch.float64)
     labels = torch.tensor([0, 0, 1])
     loss = LovaszLoss(ignore_index=IGNORE)(_logits_for(probabilities), labels)
-    assert math.isclose(loss.item(), (4 / 15 + 0.3) / 2, rel_tol=1e-9)
+    assert math.isclose(loss.item(), (4 / 15 + 3 / 10) / 2, rel_tol=1e-9)
 
 
 def test_perfect_prediction_has_zero_loss() -> None:

--- a/autoware_ml/tests/losses/test_lovasz.py
+++ b/autoware_ml/tests/losses/test_lovasz.py
@@ -15,9 +15,12 @@
 """Tests for the point-wise Lovasz-Softmax loss.
 
 The expected values come from the definition of the loss (Berman et al., 2018):
-for every class present in the labels, sort the errors ``|1[y = c] - p_c|`` in
-descending order and take their dot product with the discrete gradient of the
-Jaccard loss along that order; the loss is the mean over the present classes.
+for every class ``c`` present in the labels, the error of a point is
+``|foreground - p_c|``, where ``foreground`` is 1 if the point's label is ``c``
+and 0 otherwise, and ``p_c`` is its predicted probability for ``c``. Sort the
+errors in descending order and take their dot product with the discrete
+gradient of the Jaccard loss along that order; the loss is the mean over the
+present classes.
 """
 
 import math
@@ -39,7 +42,7 @@ def test_hand_computed_two_class_example() -> None:
     """Three points, two classes, worked through by hand from the definition.
 
     Probabilities for class 0 are 0.9, 0.6, 0.2; labels are 0, 0, 1. For each
-    present class: take the errors ``|1[y = c] - p_c|``, sort them descending,
+    present class: take the errors ``|foreground - p_c|``, sort them descending,
     and after each prefix of the sorted order compute the Jaccard loss
     ``1 - intersection / union`` between the prefix and the ground truth. The
     class term is the dot product of the sorted errors with the increments of

--- a/autoware_ml/tests/losses/test_lovasz.py
+++ b/autoware_ml/tests/losses/test_lovasz.py
@@ -42,10 +42,13 @@ def test_hand_computed_two_class_example() -> None:
     """Three points, two classes, worked through by hand from the definition.
 
     Probabilities for class 0 are 0.9, 0.6, 0.2; labels are 0, 0, 1. For each
-    present class: take the errors ``|foreground - p_c|``, sort them descending,
-    and after each prefix of the sorted order compute the Jaccard loss
-    ``1 - intersection / union`` between the prefix and the ground truth. The
-    class term is the dot product of the sorted errors with the increments of
+    present class: take the errors ``|foreground - p_c|`` and sort them
+    descending. Walk down the sorted order, and at each position treat the
+    points seen so far as the set predicted for the class: ``intersection`` is
+    the number of those points whose label is the class, ``union`` is the number
+    of points that are either seen so far or labelled the class, and the
+    Jaccard loss is ``1 - intersection / union``. The class term is the dot
+    product of the sorted errors with the position-to-position increments of
     that Jaccard loss.
 
     Class 0 (ground truth: points 0 and 1)::

--- a/autoware_ml/tests/losses/test_lovasz.py
+++ b/autoware_ml/tests/losses/test_lovasz.py
@@ -12,87 +12,139 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the point-wise Lovasz-Softmax loss."""
+"""Tests for the point-wise Lovasz-Softmax loss.
+
+The expected values come from the definition of the loss (Berman et al., 2018):
+for every class present in the labels, sort the errors ``|1[y = c] - p_c|`` in
+descending order and take their dot product with the discrete gradient of the
+Jaccard loss along that order; the loss is the mean over the present classes.
+"""
+
+import math
 
 import pytest
 import torch
 
-from autoware_ml.losses.segmentation3d.lovasz import LovaszLoss, _lovasz_grad
+from autoware_ml.losses.segmentation3d.lovasz import LovaszLoss
 
 IGNORE = -1
 
 
-def _reference_lovasz_softmax_flat(
-    probabilities: torch.Tensor, labels: torch.Tensor
-) -> torch.Tensor:
-    """The original class loop, kept as the reference for the loss."""
-    losses = []
-    for class_index in labels.unique():
-        foreground = (labels == class_index).type_as(probabilities)
-        if foreground.sum() == 0:
-            continue
-        class_errors = (foreground - probabilities[:, class_index]).abs()
-        class_errors, permutation = torch.sort(class_errors, descending=True)
-        foreground = foreground[permutation]
-        losses.append(torch.dot(class_errors, _lovasz_grad(foreground)))
-    return torch.stack(losses).mean()
+def _logits_for(probabilities: torch.Tensor) -> torch.Tensor:
+    """Logits whose softmax is exactly ``probabilities`` (zero entries allowed)."""
+    return torch.where(probabilities > 0, probabilities.log(), torch.full_like(probabilities, -1e4))
 
 
-def _random_batch(seed: int, num_points: int = 600, num_classes: int = 15):
-    generator = torch.Generator().manual_seed(seed)
-    logits = torch.randn(num_points, num_classes, generator=generator)
-    labels = torch.randint(0, num_classes, (num_points,), generator=generator)
-    labels[torch.rand(num_points, generator=generator) < 0.2] = IGNORE
-    labels[labels == 3] = 4  # a class that is absent from the batch
-    return logits, labels
+def test_hand_computed_two_class_example() -> None:
+    """Three points, two classes, worked through by hand from the definition.
+
+    Class 0 (points 0 and 1): errors 0.1, 0.4, 0.2 -> sorted 0.4, 0.2, 0.1 with
+    foreground 1, 0, 1. Intersection after each prefix: 1, 1, 0; union: 2, 3, 3;
+    Jaccard loss: 1/2, 2/3, 1; its increments: 1/2, 1/6, 1/3.
+    Loss_0 = 0.4/2 + 0.2/6 + 0.1/3 = 4/15.
+    Class 1 (point 2): errors 0.1, 0.4, 0.2 -> sorted 0.4, 0.2, 0.1 with
+    foreground 0, 1, 0. Intersection: 1, 0, 0; union: 2, 2, 3; Jaccard loss:
+    1/2, 1, 1; increments 1/2, 1/2, 0. Loss_1 = 0.4/2 + 0.2/2 = 0.3.
+    """
+    probabilities = torch.tensor([[0.9, 0.1], [0.6, 0.4], [0.2, 0.8]], dtype=torch.float64)
+    labels = torch.tensor([0, 0, 1])
+    loss = LovaszLoss(ignore_index=IGNORE)(_logits_for(probabilities), labels)
+    assert math.isclose(loss.item(), (4 / 15 + 0.3) / 2, rel_tol=1e-9)
 
 
-@pytest.mark.parametrize("seed", range(5))
-def test_lovasz_loss_matches_the_reference_class_loop(seed: int) -> None:
-    """Loss value and gradient must equal the per-class reference, with ignored
-    points excluded and absent classes contributing nothing."""
-    logits, labels = _random_batch(seed)
-    logits = logits.requires_grad_(True)
-    loss = LovaszLoss(ignore_index=IGNORE)(logits, labels)
-    (grad,) = torch.autograd.grad(loss, logits)
-
-    ref_logits = logits.detach().requires_grad_(True)
-    valid = labels != IGNORE
-    ref_loss = _reference_lovasz_softmax_flat(ref_logits.softmax(dim=1)[valid], labels[valid])
-    (ref_grad,) = torch.autograd.grad(ref_loss, ref_logits)
-
-    assert torch.allclose(loss, ref_loss, rtol=1e-6, atol=0)
-    assert torch.allclose(grad, ref_grad, rtol=1e-5, atol=1e-8)
-    assert torch.all(grad[~valid] == 0)
+def test_perfect_prediction_has_zero_loss() -> None:
+    labels = torch.tensor([0, 2, 1, 2, 0])
+    probabilities = torch.nn.functional.one_hot(labels, 3).to(torch.float64)
+    loss = LovaszLoss(ignore_index=IGNORE)(_logits_for(probabilities), labels)
+    assert loss.item() == 0.0
 
 
-def test_lovasz_loss_averages_over_present_classes_only() -> None:
-    """With a single present class the loss is that class's Lovasz term alone."""
-    logits, _ = _random_batch(0, num_points=64, num_classes=4)
-    labels = torch.full((64,), 2)
-    loss = LovaszLoss(ignore_index=IGNORE)(logits, labels)
-    probabilities = logits.softmax(dim=1)
-    errors, permutation = torch.sort((1.0 - probabilities[:, 2]).abs(), descending=True)
-    expected = torch.dot(errors, _lovasz_grad(torch.ones(64)[permutation]))
-    assert torch.allclose(loss, expected)
+def test_completely_wrong_prediction_has_unit_loss() -> None:
+    """With zero mass on the true class of every point, each present class has
+    error 1 on all its points, so its Lovasz term is the full Jaccard loss, 1."""
+    labels = torch.tensor([0, 0, 1, 1, 1, 2])
+    probabilities = torch.nn.functional.one_hot((labels + 1) % 3, 3).to(torch.float64)
+    loss = LovaszLoss(ignore_index=IGNORE)(_logits_for(probabilities), labels)
+    assert math.isclose(loss.item(), 1.0, rel_tol=1e-9)
 
 
-def test_lovasz_loss_keeps_the_graph_when_everything_is_ignored() -> None:
+def test_loss_is_bounded_by_zero_and_one() -> None:
+    generator = torch.Generator().manual_seed(0)
+    for _ in range(20):
+        logits = torch.randn(200, 7, generator=generator) * 3
+        labels = torch.randint(0, 7, (200,), generator=generator)
+        loss = LovaszLoss(ignore_index=IGNORE)(logits, labels)
+        assert 0.0 <= loss.item() <= 1.0
+
+
+def test_absent_classes_do_not_enter_the_mean() -> None:
+    """A class with no points is not averaged in: the two-class example must
+    give the same loss when a third, never-labelled class is appended with zero
+    probability, so the present classes' probabilities are unchanged."""
+    probabilities = torch.tensor([[0.9, 0.1], [0.6, 0.4], [0.2, 0.8]], dtype=torch.float64)
+    labels = torch.tensor([0, 0, 1])
+    two_class = LovaszLoss(ignore_index=IGNORE)(_logits_for(probabilities), labels)
+    padded = torch.cat([probabilities, torch.zeros(3, 1, dtype=torch.float64)], dim=1)
+    three_class = LovaszLoss(ignore_index=IGNORE)(_logits_for(padded), labels)
+    assert math.isclose(two_class.item(), three_class.item(), rel_tol=1e-9)
+    assert math.isclose(two_class.item(), (4 / 15 + 0.3) / 2, rel_tol=1e-9)
+
+
+def test_ignored_points_do_not_affect_the_loss_or_receive_gradient() -> None:
+    generator = torch.Generator().manual_seed(1)
+    logits = torch.randn(120, 5, generator=generator)
+    labels = torch.randint(0, 5, (120,), generator=generator)
+    ignored = torch.rand(120, generator=generator) < 0.3
+    labels_with_ignore = labels.clone()
+    labels_with_ignore[ignored] = IGNORE
+    loss_fn = LovaszLoss(ignore_index=IGNORE)
+
+    full = logits.clone().requires_grad_(True)
+    loss = loss_fn(full, labels_with_ignore)
+    (grad,) = torch.autograd.grad(loss, full)
+    reference = loss_fn(logits[~ignored], labels[~ignored])
+
+    assert torch.allclose(loss, reference)
+    assert torch.all(grad[ignored] == 0)
+    assert torch.any(grad[~ignored] != 0)
+
+
+def test_loss_is_invariant_to_the_order_of_points() -> None:
+    generator = torch.Generator().manual_seed(2)
+    logits = torch.randn(80, 4, generator=generator, dtype=torch.float64)
+    labels = torch.randint(0, 4, (80,), generator=generator)
+    permutation = torch.randperm(80, generator=generator)
+    loss_fn = LovaszLoss(ignore_index=IGNORE)
+    shuffled = loss_fn(logits[permutation], labels[permutation])
+    assert torch.allclose(loss_fn(logits, labels), shuffled)
+
+
+def test_gradient_matches_finite_differences() -> None:
+    """The loss is piecewise linear in the probabilities; away from ties in the
+    sort its autograd gradient must agree with central finite differences."""
+    generator = torch.Generator().manual_seed(3)
+    logits = torch.randn(12, 3, generator=generator, dtype=torch.float64).requires_grad_(True)
+    labels = torch.tensor([0, 1, 2, 0, 1, 2, 0, 0, 1, 1, 2, 2])
+    loss_fn = LovaszLoss(ignore_index=IGNORE)
+    assert torch.autograd.gradcheck(lambda x: loss_fn(x, labels), (logits,), eps=1e-6, atol=1e-5)
+
+
+def test_all_ignored_batch_keeps_the_graph() -> None:
     """An all-ignored batch yields a zero loss that still differentiates to zeros."""
-    logits, _ = _random_batch(1, num_points=32)
-    logits = logits.requires_grad_(True)
+    logits = torch.randn(32, 15, requires_grad=True)
     loss = LovaszLoss(ignore_index=IGNORE)(logits, torch.full((32,), IGNORE))
     (grad,) = torch.autograd.grad(loss, logits)
     assert loss.item() == 0.0
     assert torch.all(grad == 0)
 
 
-def test_lovasz_loss_applies_the_weight_and_per_image_mean() -> None:
-    """``per_image`` averages the per-sample losses; ``loss_weight`` scales the result."""
-    logits, labels = _random_batch(2, num_points=200)
+@pytest.mark.parametrize("weight", [1.0, 0.5])
+def test_per_image_averages_the_per_sample_losses(weight: float) -> None:
+    generator = torch.Generator().manual_seed(4)
+    logits = torch.randn(2, 5, 100, generator=generator)  # (batch, classes, points)
+    labels = torch.randint(0, 5, (2, 100), generator=generator)
+    labels[0, :10] = IGNORE
     joint = LovaszLoss(ignore_index=IGNORE)
-    per_sample = torch.stack([joint(logits[i : i + 100], labels[i : i + 100]) for i in (0, 100)])
-    per_image = LovaszLoss(ignore_index=IGNORE, per_image=True, loss_weight=0.5)(
-        logits.view(2, 100, -1).movedim(-1, 1), labels.view(2, 100)
-    )
-    assert torch.allclose(per_image, 0.5 * per_sample.mean())
+    per_sample = torch.stack([joint(logits[i].T, labels[i]) for i in range(2)])
+    per_image = LovaszLoss(ignore_index=IGNORE, per_image=True, loss_weight=weight)(logits, labels)
+    assert torch.allclose(per_image, weight * per_sample.mean())

--- a/autoware_ml/tests/losses/test_lovasz.py
+++ b/autoware_ml/tests/losses/test_lovasz.py
@@ -1,0 +1,98 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the point-wise Lovasz-Softmax loss."""
+
+import pytest
+import torch
+
+from autoware_ml.losses.segmentation3d.lovasz import LovaszLoss, _lovasz_grad
+
+IGNORE = -1
+
+
+def _reference_lovasz_softmax_flat(
+    probabilities: torch.Tensor, labels: torch.Tensor
+) -> torch.Tensor:
+    """The original class loop, kept as the reference for the loss."""
+    losses = []
+    for class_index in labels.unique():
+        foreground = (labels == class_index).type_as(probabilities)
+        if foreground.sum() == 0:
+            continue
+        class_errors = (foreground - probabilities[:, class_index]).abs()
+        class_errors, permutation = torch.sort(class_errors, descending=True)
+        foreground = foreground[permutation]
+        losses.append(torch.dot(class_errors, _lovasz_grad(foreground)))
+    return torch.stack(losses).mean()
+
+
+def _random_batch(seed: int, num_points: int = 600, num_classes: int = 15):
+    generator = torch.Generator().manual_seed(seed)
+    logits = torch.randn(num_points, num_classes, generator=generator)
+    labels = torch.randint(0, num_classes, (num_points,), generator=generator)
+    labels[torch.rand(num_points, generator=generator) < 0.2] = IGNORE
+    labels[labels == 3] = 4  # a class that is absent from the batch
+    return logits, labels
+
+
+@pytest.mark.parametrize("seed", range(5))
+def test_lovasz_loss_matches_the_reference_class_loop(seed: int) -> None:
+    """Loss value and gradient must equal the per-class reference, with ignored
+    points excluded and absent classes contributing nothing."""
+    logits, labels = _random_batch(seed)
+    logits = logits.requires_grad_(True)
+    loss = LovaszLoss(ignore_index=IGNORE)(logits, labels)
+    (grad,) = torch.autograd.grad(loss, logits)
+
+    ref_logits = logits.detach().requires_grad_(True)
+    valid = labels != IGNORE
+    ref_loss = _reference_lovasz_softmax_flat(ref_logits.softmax(dim=1)[valid], labels[valid])
+    (ref_grad,) = torch.autograd.grad(ref_loss, ref_logits)
+
+    assert torch.allclose(loss, ref_loss, rtol=1e-6, atol=0)
+    assert torch.allclose(grad, ref_grad, rtol=1e-5, atol=1e-8)
+    assert torch.all(grad[~valid] == 0)
+
+
+def test_lovasz_loss_averages_over_present_classes_only() -> None:
+    """With a single present class the loss is that class's Lovasz term alone."""
+    logits, _ = _random_batch(0, num_points=64, num_classes=4)
+    labels = torch.full((64,), 2)
+    loss = LovaszLoss(ignore_index=IGNORE)(logits, labels)
+    probabilities = logits.softmax(dim=1)
+    errors, permutation = torch.sort((1.0 - probabilities[:, 2]).abs(), descending=True)
+    expected = torch.dot(errors, _lovasz_grad(torch.ones(64)[permutation]))
+    assert torch.allclose(loss, expected)
+
+
+def test_lovasz_loss_keeps_the_graph_when_everything_is_ignored() -> None:
+    """An all-ignored batch yields a zero loss that still differentiates to zeros."""
+    logits, _ = _random_batch(1, num_points=32)
+    logits = logits.requires_grad_(True)
+    loss = LovaszLoss(ignore_index=IGNORE)(logits, torch.full((32,), IGNORE))
+    (grad,) = torch.autograd.grad(loss, logits)
+    assert loss.item() == 0.0
+    assert torch.all(grad == 0)
+
+
+def test_lovasz_loss_applies_the_weight_and_per_image_mean() -> None:
+    """``per_image`` averages the per-sample losses; ``loss_weight`` scales the result."""
+    logits, labels = _random_batch(2, num_points=200)
+    joint = LovaszLoss(ignore_index=IGNORE)
+    per_sample = torch.stack([joint(logits[i : i + 100], labels[i : i + 100]) for i in (0, 100)])
+    per_image = LovaszLoss(ignore_index=IGNORE, per_image=True, loss_weight=0.5)(
+        logits.view(2, 100, -1).movedim(-1, 1), labels.view(2, 100)
+    )
+    assert torch.allclose(per_image, 0.5 * per_sample.mean())


### PR DESCRIPTION
## Summary

`LovaszLoss._lovasz_softmax_flat` iterated `labels.unique()` directly. Iterating a CUDA tensor element by element synchronises with the device once per iteration (i.e. class).
Indexing `probabilities[:, class_index]` with the resulting 0-d CUDA tensor synchronises again, and the `foreground.sum() == 0` guard a third time. The guard is also redundant: every class that `unique` returns is present in `labels`.

The loop now iterates `labels.unique().tolist()`, a single device-to-host copy, and the guard is gone. Numerics are unchanged: the same operations run in the same order.

## Related Issues

Part of removing the per-step host synchronisations from PTv3 training; the large remainder (the attention padding loop) is addressed in a separate, independent PR.

## Checklist

- [x] You've checked our [contribution overview](https://tier4.github.io/autoware-ml/contributing/contribution-overview/).
- [x] Your PR follows our [pull request guidelines](https://tier4.github.io/autoware-ml/contributing/pull-request-guidelines/).

## Additional Notes

The loss had no unit tests. `autoware_ml/tests/losses/test_lovasz.py` derives its expected values from the definition of Lovasz loss.

Also performed a gradient check. It exposed a latent dtype issue: `_lovasz_grad` hard-cast its cumulative sums to float32, so the loss could not run on float64 inputs at all. It now keeps the caller's dtype.

## Additional Log and Media

Counted with `torch.cuda.set_sync_debug_mode("warn")` on one training step of the tiny PTv3 lidarseg configuration (`segmentation3d/ptv3/voxel012_122m_t4dataset_j6gen2`): this loop accounted for 24 of the ~3060 host synchronisations per step (two per present class). After the change it accounts for one.